### PR TITLE
Start process on websocket open.

### DIFF
--- a/nbserverproxy/handlers.py
+++ b/nbserverproxy/handlers.py
@@ -401,4 +401,4 @@ def setup_handlers(web_app):
         (url_path_join(web_app.settings['base_url'], r'/proxy/(\d+)(.*)'), LocalProxyHandler)
     ])
 
-#vim:set et ts=4 sw=4:
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
If open is called before any of the proxy methods, the supervised process doesn't get started. Share the conditional start code from proxy() into conditional_start() and call from open(). This requires asyncing open() too.