### PR TITLE
Refactor code to be cleaner

### DIFF
--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -43,11 +43,22 @@ pairs.
    * A callable that takes on parameter - ``port``, and returns a dictionary
      of strings that are used & treated same as above.
 
-#. **icon**
+#. **launcher_entry**
 
-   Full path to an icon in SVG format that may be optionally used to
-   represent this server in UI.
+   A dictionary with options on if / how an entry in the classic Jupyter Notebook
+   'New' dropdown or the JupyterLab launcher should be added. It can contain
+   the following keys:
 
+   #. **enabled**
+      Set to True (default) to make an entry in the launchers. Set to False to have no
+      explicit entry.
+
+   #. **icon_path**
+      Full path to an svg icon that could be used with a launcher. Currently only used by the
+      JupyterLab launcher
+
+   #. **title**
+      Title to be used for the launcher entry. Defaults to the name of the server if missing.
 
 Specifying config via traitlets
 ===============================

--- a/jupyter_server_proxy/static/tree.js
+++ b/jupyter_server_proxy/static/tree.js
@@ -8,8 +8,8 @@ define(['jquery', 'base/js/namespace', 'base/js/utils'], function($, Jupyter, ut
     function load() {
         if (!Jupyter.notebook_list) return;
 
-        var entries_url = base_url + 'server-proxy/servers-info' ;
-        $.get(entries_url, function(data) {
+        var servers_info_url = base_url + 'server-proxy/servers-info' ;
+        $.get(servers_info_url, function(data) {
             /* locate the right-side dropdown menu of apps and notebooks */
             var $menu = $('.tree-buttons').find('.dropdown-menu');
 
@@ -22,7 +22,11 @@ define(['jquery', 'base/js/namespace', 'base/js/utils'], function($, Jupyter, ut
             /* add the divider */
             $menu.append($divider);
 
-            $.each(data.launcher.entries, function(_, entry) {
+            $.each(data.server_processes, function(_, server_process) {
+                if (!server_process.launcher_entry.enabled) {
+                    return;
+                }
+
                 /* create our list item */
                 var $entry_container = $('<li>')
                     .attr('role', 'presentation')
@@ -32,9 +36,9 @@ define(['jquery', 'base/js/namespace', 'base/js/utils'], function($, Jupyter, ut
                 var $entry_link = $('<a>')
                     .attr('role', 'menuitem')
                     .attr('tabindex', '-1')
-                    .attr('href', base_url + entry.name + '/')
+                    .attr('href', base_url + server_process.name + '/')
                     .attr('target', '_blank')
-                    .text(entry.title);
+                    .text(server_process.launcher_entry.title);
 
                 /* add the link to the item and
                 * the item to the menu */

--- a/jupyterlab-server-proxy/src/index.ts
+++ b/jupyterlab-server-proxy/src/index.ts
@@ -6,17 +6,23 @@ import '../style/index.css';
 
 
 function addLauncherEntries(serverData: any, launcher: ILauncher, app: JupyterLab) {
-    for (let entry of serverData.launcher.entries) {
+    for (let server_process of serverData.server_processes) {
 
-      let commandId = 'server-proxy:' + entry.name;
+      if (!server_process.launcher_entry.enabled) {
+        continue;
+      }
+
+      let commandId = 'server-proxy:' + server_process.name;
+
       app.commands.addCommand(commandId, {
-        label: entry.title,
+        label: server_process.launcher_entry.title,
         execute: () => {
-          let launch_url = PageConfig.getBaseUrl() + entry.name + '/';
+          let launch_url = PageConfig.getBaseUrl() + server_process.name + '/';
           window.open(launch_url, '_blank');
         }
       });
-      let iconUrl = PageConfig.getBaseUrl() + 'server-proxy/icon/' + entry.name;
+      // FIXME: Send full icon URL with our API call
+      let iconUrl = PageConfig.getBaseUrl() + 'server-proxy/icon/' + server_process.name;
       launcher.add({
         command: commandId,
         // This is the only way to get icon URLs in here


### PR DESCRIPTION
- Use namedtuples rather than just dictionaries
  to represent config. This way, we have a shared
  definition of ServerProcess objects
- Allow turning off launcher entries for objects
