### PR TITLE
Pass in icon_url explicitly to the client

### DIFF
--- a/jupyter_server_proxy/api.py
+++ b/jupyter_server_proxy/api.py
@@ -1,6 +1,7 @@
 from tornado import web
 import mimetypes
 from notebook.base.handlers import IPythonHandler
+from notebook.utils import url_path_join as ujoin
 from collections import namedtuple
 
 class ServersInfoHandler(IPythonHandler):
@@ -14,13 +15,18 @@ class ServersInfoHandler(IPythonHandler):
         # Don't send anything that might be a callable, or leak sensitive info
         for sp in self.server_processes:
             # Manually recurse to convert namedtuples into JSONable structures
-            data.append({
+            item = {
                 'name': sp.name,
                 'launcher_entry': {
                     'enabled': sp.launcher_entry.enabled,
                     'title': sp.launcher_entry.title
                 }
-            })
+            }
+            if sp.launcher_entry.icon_path:
+                icon_url = ujoin(self.base_url, 'server-proxy', 'icon', sp.name)
+                item['launcher_entry']['icon_url'] = icon_url
+
+            data.append(item)
 
         self.write({'server_processes': data})
 

--- a/jupyterlab-server-proxy/src/index.ts
+++ b/jupyterlab-server-proxy/src/index.ts
@@ -21,14 +21,14 @@ function addLauncherEntries(serverData: any, launcher: ILauncher, app: JupyterLa
           window.open(launch_url, '_blank');
         }
       });
-      // FIXME: Send full icon URL with our API call
-      let iconUrl = PageConfig.getBaseUrl() + 'server-proxy/icon/' + server_process.name;
-      launcher.add({
+      let command : ILauncher.IItemOptions = {
         command: commandId,
-        // This is the only way to get icon URLs in here
-        category: 'Notebook',
-        kernelIconUrl: iconUrl
-      })
+        category: 'Notebook'
+      };
+      if (server_process.launcher_entry.icon_url) {
+        command.kernelIconUrl =  server_process.launcher_entry.icon_url;
+      }
+      launcher.add(command);
     }
 }
 /**


### PR DESCRIPTION
This also gives us empty icons when they aren't specified