### PR TITLE
base_url and timeout server config

### DIFF
--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -23,13 +23,23 @@ pairs.
    One of:
 
    * A list of strings that is the command used to start the
-     process. If the string ``{port}`` is present anywhere, it'll
-     be replaced with the port the process should listen on.
-    
+     process. The following template strings will be replaced:
+
+     * ``{port}`` the port the process should listen on.
+
+     * ``{base_url}`` the base URL of the notebook
+
+     For example, if the application needs to know its full path it can
+     be constructed from ``{base_url}/proxy/{port}``
+
    * A callable that takes any :ref:`callable arguments <server-process/callable-argument>`,
      and returns a list of strings that are used & treated same as above.
   
    This key is required.
+
+#. **timeout**
+
+   Timeout in seconds for the process to become ready, default ``5s``.
 
 #. **environment**
 
@@ -37,8 +47,8 @@ pairs.
 
    * A dictionary of strings that are passed in as the environment to
      the started process, in addition to the environment of the notebook
-     process itself. If the string ``{port}}`` is present anywhere,
-     it'll be replaced with the port the process should listen on.
+     process itself. The strings ``{port}`` and ``{base_url}`` will be
+     replaced as for **command**.
 
    * A callable that takes any :ref:`callable arguments <server-process/callable-argument>`,
      and returns a dictionary of strings that are used & treated same as above.
@@ -101,6 +111,9 @@ Currently, the following arguments are available:
 
 #. **port**
    The port the command should listen on
+
+#. **base_url**
+   The base URL of the notebook
 
 If any of the returned strings, lists or dictionaries contain strings
 of form ``{<argument-name>}``, they will be replaced with the value

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -114,19 +114,17 @@ class ServerProxy(Configurable):
 
         Value should be a dictionary with the following keys:
           command
-            A list of strings that should be the full command to be executed. If {{port}}  is
-            present, it'll be substituted with the port the process should listen on.
+            A list of strings that should be the full command to be executed.
+            The optional template arguments {{port}} and {{base_url}} will be substituted with the
+            port the process should listen on and the base-url of the notebook.
 
-            Could also be a callable that takes a single argument - port. It should return
-            a dictionary.
+            Could also be a callable. It should return a dictionary.
 
           environment
-            A dictionary of environment variable mappings. {{port}} will be replaced by the port
-            the process should listen on. If not explicitly set, a PORT environment variable will
-            automatically be set.
+            A dictionary of environment variable mappings. {{port}} and {{base_url}} will be
+            substituted as for command.
 
-            Could also be a callable that takes a single argument - port. It should return
-            a dictionary.
+            Could also be a callable. It should return a dictionary.
 
           timeout
             Timeout in seconds for the process to become ready, default 5s.

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -22,7 +22,8 @@ def _make_serverproxy_handler(name, command, environment, timeout):
         @property
         def process_args(self):
             return {
-                'port': self.port
+                'port': self.port,
+                'base_url': self.base_url,
             }
 
         def _render_template(self, value):

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -9,7 +9,7 @@ import pkg_resources
 from collections import namedtuple
 from .utils import call_with_asked_args
 
-def _make_serverproxy_handler(name, command, environment):
+def _make_serverproxy_handler(name, command, environment, timeout):
     """
     Create a SuperviseAndProxyHandler subclass with given parameters
     """
@@ -51,6 +51,9 @@ def _make_serverproxy_handler(name, command, environment):
             else:
                 return self._render_template(environment)
 
+        def get_timeout(self):
+            return timeout
+
     return _Proxy
 
 
@@ -71,7 +74,8 @@ def make_handlers(base_url, server_processes):
         handler = _make_serverproxy_handler(
             sp.name,
             sp.command,
-            sp.environment
+            sp.environment,
+            sp.timeout,
         )
         handlers.append((
             ujoin(base_url, sp.name, r'(.*)'), handler, dict(state={}),
@@ -82,7 +86,7 @@ def make_handlers(base_url, server_processes):
     return handlers
 
 LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title'])
-ServerProcess = namedtuple('ServerProcess', ['name', 'command', 'environment', 'launcher_entry'])
+ServerProcess = namedtuple('ServerProcess', ['name', 'command', 'environment', 'timeout', 'launcher_entry'])
 
 def make_server_process(name, server_process_config):
     le = server_process_config.get('launcher_entry', {})
@@ -90,6 +94,7 @@ def make_server_process(name, server_process_config):
         name=name,
         command=server_process_config['command'],
         environment=server_process_config.get('environment', {}),
+        timeout=server_process_config.get('timeout', 5),
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),
             icon_path=le.get('icon_path'),
@@ -121,6 +126,9 @@ class ServerProxy(Configurable):
 
             Could also be a callable that takes a single argument - port. It should return
             a dictionary.
+
+          timeout
+            Timeout in seconds for the process to become ready, default 5s.
 
           launcher_entry
             A dictionary of various options for entries in classic notebook / jupyterlab launchers.

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -316,7 +316,9 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
                 # Set up extra environment variables for process
                 server_env.update(self.get_env())
 
-                proc = SupervisedProcess(self.name, *cmd, env=server_env, ready_func=self._http_ready_func, log=self.log)
+                timeout = self.get_timeout()
+
+                proc = SupervisedProcess(self.name, *cmd, env=server_env, ready_func=self._http_ready_func, ready_timeout=timeout, log=self.log)
                 self.state['proc'] = proc
 
                 try:

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -287,6 +287,12 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
            overridden in subclasses.'''
         return {}
 
+    def get_timeout(self):
+        """
+        Return timeout (in s) to wait before giving up on process readiness
+        """
+        return 5
+
     async def _http_ready_func(self, p):
         url = 'http://localhost:{}'.format(self.port)
         async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
Adds a timeout parameter for the readiness check, this is needed for applications that are slow to start. The default is `5s` which matches the current timeout from https://github.com/yuvipanda/simpervisor/blob/b736f117f30ab59db7fbd2ae7637b9fdf6d0295d/simpervisor/process.py#L19

Adds `{base_url}` as a template parameter for configuring servers. This is useful for applications such as many Django apps which need to know their visible path.