### PR TITLE
Call command / environment with only args they ask for

### DIFF
--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -91,7 +91,7 @@ with:
        'command': _cmd_callback
    }
 
-The ``port`` argument will be pased to the callable. This is a simple form of dependency
+The ``port`` argument will be passed to the callable. This is a simple form of dependency
 injection that helps us add more parameters in the future without breaking backwards
 compatibility.
 

--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -26,8 +26,8 @@ pairs.
      process. If the string ``{port}`` is present anywhere, it'll
      be replaced with the port the process should listen on.
     
-   * A callable that takes one parameter - ``port``, and returns a
-     list of strings that are used & treated same as above.
+   * A callable that takes any :ref:`callable arguments <server-process/callable-argument>`,
+     and returns a list of strings that are used & treated same as above.
   
    This key is required.
 
@@ -40,8 +40,8 @@ pairs.
      process itself. If the string ``{port}}`` is present anywhere,
      it'll be replaced with the port the process should listen on.
 
-   * A callable that takes on parameter - ``port``, and returns a dictionary
-     of strings that are used & treated same as above.
+   * A callable that takes any :ref:`callable arguments <server-process/callable-argument>`,
+     and returns a dictionary of strings that are used & treated same as above.
 
 #. **launcher_entry**
 
@@ -59,6 +59,60 @@ pairs.
 
    #. **title**
       Title to be used for the launcher entry. Defaults to the name of the server if missing.
+
+.. _server-processes/callable-arguments:
+
+Callable arguments
+------------------
+
+Any time you specify a callable in the config, it can ask for any arguments it needs
+by simply declaring it - only arguments the callable asks for will be passed to it.
+
+For example, with the following config:
+
+.. code:: python
+
+   def _cmd_callback():
+       return ['some-command']
+
+   server_config = {
+       'command': _cmd_callback
+   }
+
+No arguments will be passed to ``_cmd_callback``, since it doesn't ask for any. However,
+with:
+
+.. code:: python
+
+   def _cmd_callback(port):
+       return ['some-command', '--port=' + str(port)]
+
+   server_config = {
+       'command': _cmd_callback
+   }
+
+The ``port`` argument will be pased to the callable. This is a simple form of dependency
+injection that helps us add more parameters in the future without breaking backwards
+compatibility.
+
+Available arguments
+~~~~~~~~~~~~~~~~~~~
+Currently, the following arguments are available:
+
+#. **port**
+   The port the command should listen on
+
+If any of the returned strings, lists or dictionaries contain strings
+of form ``{<argument-name>}``, they will be replaced with the value
+of the argument. For example, if your function is:
+
+.. code:: python
+
+   def _openrefine_cmd():
+       return ['openrefine', '-p', '{port}']
+
+The ``{port}`` will be replaced with the appropriate port before
+the command is started
 
 Specifying config via traitlets
 ===============================

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -7,6 +7,7 @@ from traitlets.config import Configurable
 from .handlers import SuperviseAndProxyHandler, AddSlashHandler
 import pkg_resources
 from collections import namedtuple
+from .utils import call_with_asked_args
 
 def _make_serverproxy_handler(name, command, environment):
     """
@@ -40,13 +41,13 @@ def _make_serverproxy_handler(name, command, environment):
 
         def get_cmd(self):
             if callable(command):
-                return self._render_template(command(**self.process_args))
+                return self._render_template(call_with_asked_args(command, self.process_args))
             else:
                 return self._render_template(command)
 
         def get_env(self):
             if callable(environment):
-                return self._render_template(environment(**self.process_args))
+                return self._render_template(call_with_asked_args(environment, self.process_args))
             else:
                 return self._render_template(environment)
 

--- a/jupyter_server_proxy/utils.py
+++ b/jupyter_server_proxy/utils.py
@@ -21,7 +21,6 @@ def call_with_asked_args(callback, args):
             asked_arg_values.append(args[asked_arg_name])
         else:
             missing_args.append(asked_arg_name)
-    print(asked_arg_values)
     if missing_args:
         raise TypeError(
             '{}() missing required positional argument: {}'.format(

--- a/jupyter_server_proxy/utils.py
+++ b/jupyter_server_proxy/utils.py
@@ -1,0 +1,32 @@
+def call_with_asked_args(callback, args):
+    """
+    Call callback only the args it wants from args
+
+    Example
+    >>> def cb(a):
+    ...    return a * 5
+
+    >>> print(call_with_asked_args(cb, {'a': 4, 'b': 8}))
+    20
+    """
+    # FIXME: support default args
+    # FIXME: support kwargs
+    # co_varnames contains both args and local variables, in order. 
+    # We only pick the local variables
+    asked_arg_names = callback.__code__.co_varnames[:callback.__code__.co_argcount]
+    asked_arg_values = []
+    missing_args = []
+    for asked_arg_name in asked_arg_names:
+        if asked_arg_name in args:
+            asked_arg_values.append(args[asked_arg_name])
+        else:
+            missing_args.append(asked_arg_name)
+    print(asked_arg_values)
+    if missing_args:
+        raise TypeError(
+            '{}() missing required positional argument: {}'.format(
+                callback.__code__.co_name,
+                ', '.join(missing_args)
+            )
+        )
+    return callback(*asked_arg_values)

--- a/jupyter_server_proxy/utils.py
+++ b/jupyter_server_proxy/utils.py
@@ -1,6 +1,6 @@
 def call_with_asked_args(callback, args):
     """
-    Call callback only the args it wants from args
+    Call callback with only the args it wants from args
 
     Example
     >>> def cb(a):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+from jupyter_server_proxy import utils
+
+
+def test_call_with_asked_args():
+    def _test_func(a, b):
+        c = a * b
+        return c
+
+    assert utils.call_with_asked_args(_test_func, {
+        'a': 5,
+        'b': 4,
+        'c': 8
+    }) == 20


### PR DESCRIPTION
This lets us add more parameters in the future without
breaking backwards compatibility
