### PR TITLE
Configure absolute and server URL prefixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ python:
 - 3.5
 
 script:
-  - true
+  - pip3 install .
+  - pip3 install pytest
+  - JUPYTER_TOKEN=secret jupyter-notebook --config=./tests/resources/jupyter_server_config.py &
+  - sleep 5
+  - pytest
 
 deploy:
   provider: pypi

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -18,6 +18,7 @@ def _make_serverproxy_handler(name, command, environment, timeout):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.name = name
+            self.proxy_base = name
 
         @property
         def process_args(self):

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -4,32 +4,22 @@ Traitlets based configuration for jupyter_server_proxy
 from notebook.utils import url_path_join as ujoin
 from traitlets import Dict
 from traitlets.config import Configurable
-from .handlers import (
-    SuperviseAndProxyHandler,
-    SuperviseAndAbsoluteProxyHandler,
-    AddSlashHandler,
-)
+from .handlers import SuperviseAndProxyHandler, AddSlashHandler
 import pkg_resources
 from collections import namedtuple
 from .utils import call_with_asked_args
 
 def _make_serverproxy_handler(name, command, environment, timeout, rewrite):
     """
-    Create a Supervise*ProxyHandler subclass with given parameters
+    Create a SuperviseAndProxyHandler subclass with given parameters
     """
-    if rewrite == '':
-        base_class = SuperviseAndAbsoluteProxyHandler
-    elif rewrite == '/':
-        base_class = SuperviseAndProxyHandler
-    else:
-        raise ValueError('Unsupported rewrite value "{}"'.format(rewrite))
-
     # FIXME: Set 'name' properly
-    class _Proxy(base_class):
+    class _Proxy(SuperviseAndProxyHandler):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.name = name
             self.proxy_base = name
+            self.rewrite = rewrite
 
         @property
         def process_args(self):

--- a/tests/resources/httpinfo.py
+++ b/tests/resources/httpinfo.py
@@ -1,0 +1,17 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import sys
+
+class EchoRequestInfo(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/plain")
+        self.end_headers()
+        self.wfile.write('{}\n'.format(self.requestline).encode())
+        self.wfile.write('{}\n'.format(self.headers).encode())
+
+
+if __name__ == '__main__':
+    port = int(sys.argv[1])
+    server_address = ('', port)
+    httpd = HTTPServer(server_address, EchoRequestInfo)
+    httpd.serve_forever()

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -1,0 +1,10 @@
+c.ServerProxy.servers = {
+    'python-http': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+    },
+    'python-http-abs': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'rewrite': '',
+    },
+}
+#c.Application.log_level = 'DEBUG'

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -1,0 +1,32 @@
+#from submodule import
+
+#def setup_module(module):
+import os
+from http.client import HTTPConnection
+
+PORT = os.getenv('TEST_PORT', 8888)
+TOKEN = os.getenv('JUPYTER_TOKEN', 'secret')
+
+
+def request_get(port, path, token):
+    h = HTTPConnection('localhost', port, 10)
+    h.request('GET', '{}?token={}'.format(path, token))
+    return h.getresponse()
+
+
+def test_server_proxy_rewrite():
+    r = request_get(PORT, '/python-http/abc', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /abc?token=')
+    assert 'X-Forwarded-Context: /python-http\n' in s
+    assert 'X-Proxycontextpath: /python-http\n' in s
+
+
+def test_server_proxy_absolute():
+    r = request_get(PORT, '/python-http-abs/def', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /python-http-abs/def?token=')
+    assert 'X-Forwarded-Context' not in s
+    assert 'X-Proxycontextpath' not in s


### PR DESCRIPTION
This started off as a fix for the `X-Forwarded-Context` `X-ProxyContextPath`. Previously they were always `/proxy/{port}`, now they should be `/server-name` if this is a managed server. Since this is related to the code that controls the URL rewriting I thought I'd add in support for absolute URLs.

I've done some testing with:
```
c.ServerProxy.servers = {
    'python-http': {
        'command': ['python3', '-m', 'http.server', '{port}'],
    },
    'python-http-abs': {
        'command': ['python3', '-m', 'http.server', '{port}'],
        'rewrite': '',
    },
}
```
`python-http` should produce logs like
```
"GET / HTTP/1.1" 200 -
```
`python-http-abs` should produce logs like
```
"GET /python-http-abs/ HTTP/1.1" 404 -
```
Also `/proxy-abs/port` is the absolute version of `/proxy/port`

Needs more testing! @jacobtomlinson @psychemedia 

Closes https://github.com/jupyterhub/jupyter-server-proxy/issues/43
