### PR TITLE
Configure absolute and server URL prefixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ python:
 - 3.5
 
 script:
-  - true
+  - pip3 install .
+  - pip3 install pytest
+  - JUPYTER_TOKEN=secret jupyter-notebook --config=./tests/resources/jupyter_server_config.py &
+  - sleep 5
+  - pytest
 
 deploy:
   provider: pypi

--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -81,6 +81,8 @@ pairs.
 
    This is very useful with applications that require a ``base_url`` to be set.
 
+   Defaults to *False*.
+
 
 #. **launcher_entry**
 

--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -56,6 +56,32 @@ pairs.
    * A callable that takes any :ref:`callable arguments <server-process/callable-argument>`,
      and returns a dictionary of strings that are used & treated same as above.
 
+#. **absolute_url**
+
+   *True* if the URL as seen by the proxied application should be the full URL
+   sent by the user. *False* if the URL as seen by the proxied application should
+   see the URL after the parts specific to jupyter-server-proxy have been stripped.
+
+   For example, with the following config:
+
+   .. code:: python
+
+      c.ServerProxy.servers = {
+        'test-server': {
+          'command': ['python3', '-m', 'http.server', '{port}'],
+          'absolute_url': False
+        }
+      }
+
+   When a user requests ``/test-server/some-url``, the proxied server will see it
+   as a request for ``/some-url`` - the ``/test-server`` part is stripped out.
+
+   If ``absolute_url`` is set to ``True`` instead, the proxied server will see it
+   as a request for ``/test-server/some-url`` instead - without any stripping.
+
+   This is very useful with applications that require a ``base_url`` to be set.
+
+
 #. **launcher_entry**
 
    A dictionary with options on if / how an entry in the classic Jupyter Notebook

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -9,7 +9,7 @@ import pkg_resources
 from collections import namedtuple
 from .utils import call_with_asked_args
 
-def _make_serverproxy_handler(name, command, environment, timeout, rewrite):
+def _make_serverproxy_handler(name, command, environment, timeout, absolute_url):
     """
     Create a SuperviseAndProxyHandler subclass with given parameters
     """
@@ -19,7 +19,7 @@ def _make_serverproxy_handler(name, command, environment, timeout, rewrite):
             super().__init__(*args, **kwargs)
             self.name = name
             self.proxy_base = name
-            self.rewrite = rewrite
+            self.absolute_url = absolute_url
 
         @property
         def process_args(self):
@@ -79,7 +79,7 @@ def make_handlers(base_url, server_processes):
             sp.command,
             sp.environment,
             sp.timeout,
-            sp.rewrite,
+            sp.absolute_url,
         )
         handlers.append((
             ujoin(base_url, sp.name, r'(.*)'), handler, dict(state={}),
@@ -91,7 +91,7 @@ def make_handlers(base_url, server_processes):
 
 LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title'])
 ServerProcess = namedtuple('ServerProcess', [
-    'name', 'command', 'environment', 'timeout', 'rewrite', 'launcher_entry'])
+    'name', 'command', 'environment', 'timeout', 'absolute_url', 'launcher_entry'])
 
 def make_server_process(name, server_process_config):
     le = server_process_config.get('launcher_entry', {})
@@ -100,7 +100,7 @@ def make_server_process(name, server_process_config):
         command=server_process_config['command'],
         environment=server_process_config.get('environment', {}),
         timeout=server_process_config.get('timeout', 5),
-        rewrite=server_process_config.get('rewrite', '/'),
+        absolute_url=server_process_config.get('absolute_url', False),
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),
             icon_path=le.get('icon_path'),
@@ -134,9 +134,9 @@ class ServerProxy(Configurable):
           timeout
             Timeout in seconds for the process to become ready, default 5s.
 
-          rewrite
-            Proxy requests default to being rewritten to '/'. If this is ''
-            (empty) the absolute URL will be sent to the backend instead.
+          absolute_url
+            Proxy requests default to being rewritten to '/'. If this is True,
+            the absolute URL will be sent to the backend instead.
 
           launcher_entry
             A dictionary of various options for entries in classic notebook / jupyterlab launchers.

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -18,6 +18,7 @@ def _make_serverproxy_handler(name, command, environment, timeout):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.name = name
+            self.proxy_base = name
 
         @property
         def process_args(self):

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -4,32 +4,22 @@ Traitlets based configuration for jupyter_server_proxy
 from notebook.utils import url_path_join as ujoin
 from traitlets import Dict
 from traitlets.config import Configurable
-from .handlers import (
-    SuperviseAndProxyHandler,
-    SuperviseAndAbsoluteProxyHandler,
-    AddSlashHandler,
-)
+from .handlers import SuperviseAndProxyHandler, AddSlashHandler
 import pkg_resources
 from collections import namedtuple
 from .utils import call_with_asked_args
 
 def _make_serverproxy_handler(name, command, environment, timeout, rewrite):
     """
-    Create a Supervise*ProxyHandler subclass with given parameters
+    Create a SuperviseAndProxyHandler subclass with given parameters
     """
-    if rewrite == '':
-        base_class = SuperviseAndAbsoluteProxyHandler
-    elif rewrite == '/':
-        base_class = SuperviseAndProxyHandler
-    else:
-        raise ValueError('Unsupported rewrite value "{}"'.format(rewrite))
-
     # FIXME: Set 'name' properly
-    class _Proxy(base_class):
+    class _Proxy(SuperviseAndProxyHandler):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.name = name
             self.proxy_base = name
+            self.rewrite = rewrite
 
         @property
         def process_args(self):

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -167,6 +167,7 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         # Some applications check X-Forwarded-Context and X-ProxyContextPath
         # headers to see if and where they are being proxied from.
         if not self.absolute_url:
+            context_path = self._get_context_path(port)
             headers['X-Forwarded-Context'] = context_path
             headers['X-ProxyContextPath'] = context_path
 

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -30,7 +30,10 @@ class AddSlashHandler(IPythonHandler):
 
 class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
 
-    proxy_base = ''
+    def __init__(self, *args, **kwargs):
+        self.proxy_base = ''
+        self.rewrite = kwargs.pop('rewrite', '/')
+        super().__init__(*args, **kwargs)
 
     async def open(self, port, proxied_path=''):
         """
@@ -132,17 +135,30 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
     def _get_context_path(self, port):
         """
         Some applications need to know where they are being proxied from.
-        This is either {base_url}/proxy/{port} or {base_url}/{proxy_base}.
+        This is either:
+        - {base_url}/proxy/{port}
+        - {base_url}/proxy/absolute/{port}
+        - {base_url}/{proxy_base}
         """
         if self.proxy_base:
             return url_path_join(self.base_url, self.proxy_base)
-        return url_path_join(self.base_url, 'proxy', str(port))
+        if self.rewrite == '/':
+            return url_path_join(self.base_url, 'proxy', str(port))
+        if self.rewrite == '':
+            return url_path_join(self.base_url, 'proxy', 'absolute', str(port))
+        raise ValueError('Unsupported rewrite: "{}"'.format(self.rewrite))
 
-    def build_proxy_request(self, port, proxied_path, body):
+    def _build_proxy_request(self, port, proxied_path, body):
+        context_path = self._get_context_path(port)
+        if self.rewrite:
+            client_path = proxied_path
+        else:
+            client_path = url_path_join(context_path, proxied_path)
+
         client_uri = '{uri}:{port}{path}'.format(
             uri='http://localhost',
             port=port,
-            path=proxied_path
+            path=client_path
         )
         if self.request.query:
             client_uri += '?' + self.request.query
@@ -151,8 +167,9 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
 
         # Some applications check X-Forwarded-Context and X-ProxyContextPath
         # headers to see if and where they are being proxied from.
-        headers['X-Forwarded-Context'] = headers['X-ProxyContextPath'] = \
-            self._get_context_path(port)
+        if self.rewrite == '/':
+            headers['X-Forwarded-Context'] = context_path
+            headers['X-ProxyContextPath'] = context_path
 
         req = httpclient.HTTPRequest(
             client_uri, method=self.request.method, body=body,
@@ -162,13 +179,10 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
     @web.authenticated
     async def proxy(self, port, proxied_path):
         '''
-        While self.request.uri is
-            (hub)    /user/username/proxy/([0-9]+)/something.
-            (single) /proxy/([0-9]+)/something
-        or if proxy_base is set
-            (hub)    /user/username/{proxy_base}/something.
-            (single) /{proxy_base}/something
-        This serverextension is given {port}/{everything/after}.
+        This serverextension handles:
+            {base_url}/proxy/{port([0-9]+)}/{proxied_path}
+            {base_url}/proxy/absolute/{port([0-9]+)}/{proxied_path}
+            {base_url}/{proxy_base}/{proxied_path}
         '''
 
         if 'Proxy-Connection' in self.request.headers:
@@ -191,7 +205,7 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
 
         client = httpclient.AsyncHTTPClient()
 
-        req = self.build_proxy_request(port, proxied_path, body)
+        req = self._build_proxy_request(port, proxied_path, body)
         response = await client.fetch(req, raise_error=False)
         # record activity at start and end of requests
         self._record_activity()
@@ -266,32 +280,8 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         return super().select_subprotocol(subprotocols)
 
 
-class LocalAbsoluteProxyHandler(LocalProxyHandler):
-
-    def _get_context_path(self, port):
-        if self.proxy_base:
-            return super()._get_context_path(port)
-        return url_path_join(self.base_url, 'proxy-abs', str(port))
-
-    def build_proxy_request(self, port, proxied_path, body):
-        context_path = self._get_context_path(port)
-        client_uri = '{uri}:{port}{path}'.format(
-            uri='http://localhost',
-            port=port,
-            path=url_path_join(context_path, proxied_path),
-        )
-        if self.request.query:
-            client_uri += '?' + self.request.query
-
-        headers = self.proxy_request_headers()
-
-        req = httpclient.HTTPRequest(
-            client_uri, method=self.request.method, body=body,
-            headers=headers, **self.proxy_request_options())
-        return req
-
-
-class SuperviseAndProxyHandlerBase(IPythonHandler):
+# FIXME: Move this to its own file. Too many packages now import this from nbrserverproxy.handlers
+class SuperviseAndProxyHandler(LocalProxyHandler):
     '''Manage a given process and requests to it '''
 
     def initialize(self, state):
@@ -418,20 +408,13 @@ class SuperviseAndProxyHandlerBase(IPythonHandler):
         return self.proxy(self.port, path)
 
 
-# FIXME: Move this to its own file. Too many packages now import this from nbrserverproxy.handlers
-class SuperviseAndProxyHandler(SuperviseAndProxyHandlerBase, LocalProxyHandler):
-    pass
-
-
-class SuperviseAndAbsoluteProxyHandler(SuperviseAndProxyHandlerBase, LocalAbsoluteProxyHandler):
-    pass
-
-
 def setup_handlers(web_app):
     host_pattern = '.*$'
     web_app.add_handlers('.*', [
-        (url_path_join(web_app.settings['base_url'], r'/proxy/(\d+)(.*)'), LocalProxyHandler),
-        (url_path_join(web_app.settings['base_url'], r'/proxy-abs/(\d+)(.*)'), LocalAbsoluteProxyHandler),
+        (url_path_join(web_app.settings['base_url'], r'/proxy/(\d+)(.*)'),
+         LocalProxyHandler, {'rewrite': '/'}),
+        (url_path_join(web_app.settings['base_url'], r'/proxy/absolute/(\d+)(.*)'),
+         LocalProxyHandler, {'rewrite': ''}),
     ])
 
 # vim: set et ts=4 sw=4:

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -138,7 +138,7 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
             return url_path_join(self.base_url, self.proxy_base)
         return url_path_join(self.base_url, 'proxy', str(port))
 
-    def build_proxy_request(self, port, proxied_path, body, headers, options):
+    def build_proxy_request(self, port, proxied_path, body):
         client_uri = '{uri}:{port}{path}'.format(
             uri='http://localhost',
             port=port,
@@ -147,9 +147,16 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         if self.request.query:
             client_uri += '?' + self.request.query
 
+        headers = self.proxy_request_headers()
+
+        # Some applications check X-Forwarded-Context and X-ProxyContextPath
+        # headers to see if and where they are being proxied from.
+        headers['X-Forwarded-Context'] = headers['X-ProxyContextPath'] = \
+            self._get_context_path(port)
+
         req = httpclient.HTTPRequest(
             client_uri, method=self.request.method, body=body,
-            headers=headers, **options)
+            headers=headers, **self.proxy_request_options())
         return req
 
     @web.authenticated
@@ -184,15 +191,7 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
 
         client = httpclient.AsyncHTTPClient()
 
-        headers = self.proxy_request_headers()
-
-        # Some applications check X-Forwarded-Context and X-ProxyContextPath
-        # headers to see if and where they are being proxied from.
-        headers['X-Forwarded-Context'] = headers['X-ProxyContextPath'] = \
-            self._get_context_path(port)
-
-        req = self.build_proxy_request(
-            port, proxied_path, body, headers, self.proxy_request_options())
+        req = self.build_proxy_request(port, proxied_path, body)
         response = await client.fetch(req, raise_error=False)
         # record activity at start and end of requests
         self._record_activity()
@@ -267,8 +266,32 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         return super().select_subprotocol(subprotocols)
 
 
-# FIXME: Move this to its own file. Too many packages now import this from nbrserverproxy.handlers
-class SuperviseAndProxyHandler(LocalProxyHandler):
+class LocalAbsoluteProxyHandler(LocalProxyHandler):
+
+    def _get_context_path(self, port):
+        if self.proxy_base:
+            return super()._get_context_path(port)
+        return url_path_join(self.base_url, 'proxy-abs', str(port))
+
+    def build_proxy_request(self, port, proxied_path, body):
+        context_path = self._get_context_path(port)
+        client_uri = '{uri}:{port}{path}'.format(
+            uri='http://localhost',
+            port=port,
+            path=url_path_join(context_path, proxied_path),
+        )
+        if self.request.query:
+            client_uri += '?' + self.request.query
+
+        headers = self.proxy_request_headers()
+
+        req = httpclient.HTTPRequest(
+            client_uri, method=self.request.method, body=body,
+            headers=headers, **self.proxy_request_options())
+        return req
+
+
+class SuperviseAndProxyHandlerBase(IPythonHandler):
     '''Manage a given process and requests to it '''
 
     def initialize(self, state):
@@ -394,10 +417,21 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
     def options(self, path):
         return self.proxy(self.port, path)
 
+
+# FIXME: Move this to its own file. Too many packages now import this from nbrserverproxy.handlers
+class SuperviseAndProxyHandler(SuperviseAndProxyHandlerBase, LocalProxyHandler):
+    pass
+
+
+class SuperviseAndAbsoluteProxyHandler(SuperviseAndProxyHandlerBase, LocalAbsoluteProxyHandler):
+    pass
+
+
 def setup_handlers(web_app):
     host_pattern = '.*$'
     web_app.add_handlers('.*', [
-        (url_path_join(web_app.settings['base_url'], r'/proxy/(\d+)(.*)'), LocalProxyHandler)
+        (url_path_join(web_app.settings['base_url'], r'/proxy/(\d+)(.*)'), LocalProxyHandler),
+        (url_path_join(web_app.settings['base_url'], r'/proxy-abs/(\d+)(.*)'), LocalAbsoluteProxyHandler),
     ])
 
 # vim: set et ts=4 sw=4:

--- a/tests/resources/httpinfo.py
+++ b/tests/resources/httpinfo.py
@@ -1,0 +1,17 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import sys
+
+class EchoRequestInfo(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/plain")
+        self.end_headers()
+        self.wfile.write('{}\n'.format(self.requestline).encode())
+        self.wfile.write('{}\n'.format(self.headers).encode())
+
+
+if __name__ == '__main__':
+    port = int(sys.argv[1])
+    server_address = ('', port)
+    httpd = HTTPServer(server_address, EchoRequestInfo)
+    httpd.serve_forever()

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -1,0 +1,10 @@
+c.ServerProxy.servers = {
+    'python-http': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+    },
+    'python-http-abs': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'rewrite': '',
+    },
+}
+#c.Application.log_level = 'DEBUG'

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -4,7 +4,7 @@ c.ServerProxy.servers = {
     },
     'python-http-abs': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
-        'rewrite': '',
+        'absolute_url': True
     },
 }
 #c.Application.log_level = 'DEBUG'

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -11,7 +11,7 @@ def request_get(port, path, token):
     return h.getresponse()
 
 
-def test_server_proxy_rewrite():
+def test_server_proxy_non_absolute():
     r = request_get(PORT, '/python-http/abc', TOKEN)
     assert r.code == 200
     s = r.read().decode('ascii')

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -1,0 +1,29 @@
+import os
+from http.client import HTTPConnection
+
+PORT = os.getenv('TEST_PORT', 8888)
+TOKEN = os.getenv('JUPYTER_TOKEN', 'secret')
+
+
+def request_get(port, path, token):
+    h = HTTPConnection('localhost', port, 10)
+    h.request('GET', '{}?token={}'.format(path, token))
+    return h.getresponse()
+
+
+def test_server_proxy_rewrite():
+    r = request_get(PORT, '/python-http/abc', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /abc?token=')
+    assert 'X-Forwarded-Context: /python-http\n' in s
+    assert 'X-Proxycontextpath: /python-http\n' in s
+
+
+def test_server_proxy_absolute():
+    r = request_get(PORT, '/python-http-abs/def', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /python-http-abs/def?token=')
+    assert 'X-Forwarded-Context' not in s
+    assert 'X-Proxycontextpath' not in s


### PR DESCRIPTION
This started off as a fix for the `X-Forwarded-Context` `X-ProxyContextPath`. Previously they were always `/proxy/{port}`, now they should be `/server-name` if this is a managed server. Since this is related to the code that controls the URL rewriting I thought I'd add in support for absolute URLs.

I've done some testing with:
```
c.ServerProxy.servers = {
    'python-http': {
        'command': ['python3', '-m', 'http.server', '{port}'],
    },
    'python-http-abs': {
        'command': ['python3', '-m', 'http.server', '{port}'],
        'rewrite': '',
    },
}
```
`python-http` should produce logs like
```
"GET / HTTP/1.1" 200 -
```
`python-http-abs` should produce logs like
```
"GET /python-http-abs/ HTTP/1.1" 404 -
```
Also `/proxy-abs/port` is the absolute version of `/proxy/port`

Needs more testing! @jacobtomlinson @psychemedia 

Closes https://github.com/jupyterhub/jupyter-server-proxy/issues/43
