### PR TITLE
Count process as ready if it can respond

### DIFF
--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -41,6 +41,9 @@ pairs.
 
    Timeout in seconds for the process to become ready, default ``5s``.
 
+   A process is considered 'ready' when it can return a valid HTTP response on the
+   port it is supposed to start at.
+
 #. **environment**
 
    One of:

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -298,8 +298,10 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
         async with aiohttp.ClientSession() as session:
             try:
                 async with session.get(url) as resp:
+                    # We only care if we get back *any* response, not just 200
+                    # If there's an error response, that can be shown directly to the user
                     self.log.debug('Got code {} back from {}'.format(resp.status, url))
-                    return resp.status == 200
+                    return True
             except aiohttp.ClientConnectionError:
                 self.log.debug('Connection to {} refused'.format(url))
                 return False

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from glob import glob
 
 setuptools.setup(
     name="jupyter-server-proxy",
-    version='1.0beta7',
+    version='1.0beta8',
     url="https://github.com/jupyterhub/jupyter-server-proxy",
     author="Ryan Lovett & Yuvi Panda",
     author_email="rylo@berkeley.edu",


### PR DESCRIPTION
Our 'readyness' condition check is to make sure we can show
something to the user - it doesn't matter if it is a non-200 response.
Primarily, we were getting 404s and other responses that were causing
issues here - 3xxs were resolved by aiohttp.