### PR TITLE
Configure port for servers

### DIFF
--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -84,6 +84,12 @@ pairs.
    Defaults to *False*.
 
 
+ #. **port**
+
+     Set the port that the service will listen on. The default is to
+     automatically select an unused port.
+
+
 #. **launcher_entry**
 
    A dictionary with options on if / how an entry in the classic Jupyter Notebook

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -9,7 +9,7 @@ import pkg_resources
 from collections import namedtuple
 from .utils import call_with_asked_args
 
-def _make_serverproxy_handler(name, command, environment, timeout, absolute_url):
+def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port):
     """
     Create a SuperviseAndProxyHandler subclass with given parameters
     """
@@ -20,6 +20,7 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url)
             self.name = name
             self.proxy_base = name
             self.absolute_url = absolute_url
+            self.requested_port = port
 
         @property
         def process_args(self):
@@ -80,6 +81,7 @@ def make_handlers(base_url, server_processes):
             sp.environment,
             sp.timeout,
             sp.absolute_url,
+            sp.port,
         )
         handlers.append((
             ujoin(base_url, sp.name, r'(.*)'), handler, dict(state={}),
@@ -91,7 +93,7 @@ def make_handlers(base_url, server_processes):
 
 LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title'])
 ServerProcess = namedtuple('ServerProcess', [
-    'name', 'command', 'environment', 'timeout', 'absolute_url', 'launcher_entry'])
+    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'launcher_entry'])
 
 def make_server_process(name, server_process_config):
     le = server_process_config.get('launcher_entry', {})
@@ -101,6 +103,7 @@ def make_server_process(name, server_process_config):
         environment=server_process_config.get('environment', {}),
         timeout=server_process_config.get('timeout', 5),
         absolute_url=server_process_config.get('absolute_url', False),
+        port=server_process_config.get('port', 0),
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),
             icon_path=le.get('icon_path'),
@@ -137,6 +140,9 @@ class ServerProxy(Configurable):
           absolute_url
             Proxy requests default to being rewritten to '/'. If this is True,
             the absolute URL will be sent to the backend instead.
+
+          port
+            Set the port that the service will listen on. The default is to automatically select an unused port.
 
           launcher_entry
             A dictionary of various options for entries in classic notebook / jupyterlab launchers.

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -284,6 +284,10 @@ class LocalProxyHandler(WebSocketHandlerMixin, IPythonHandler):
 class SuperviseAndProxyHandler(LocalProxyHandler):
     '''Manage a given process and requests to it '''
 
+    def __init__(self, *args, **kwargs):
+        self.requested_port = 0
+        super().__init__(*args, **kwargs)
+
     def initialize(self, state):
         self.state = state
         if 'proc_lock' not in state:
@@ -294,11 +298,12 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
     @property
     def port(self):
         """
-        Allocate a random empty port for use by application
+        Allocate either the requested port or a random empty port for use by
+        application
         """
         if 'port' not in self.state:
             sock = socket.socket()
-            sock.bind(('', 0))
+            sock.bind(('', self.requested_port))
             self.state['port'] = sock.getsockname()[1]
             sock.close()
         return self.state['port']

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -6,5 +6,9 @@ c.ServerProxy.servers = {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
         'absolute_url': True
     },
+    'python-http-port54321': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'port': 54321,
+    },
 }
 #c.Application.log_level = 'DEBUG'

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -27,3 +27,33 @@ def test_server_proxy_absolute():
     assert s.startswith('GET /python-http-abs/def?token=')
     assert 'X-Forwarded-Context' not in s
     assert 'X-Proxycontextpath' not in s
+
+
+def test_server_proxy_requested_port():
+    r = request_get(PORT, '/python-http-port54321/ghi', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /ghi?token=')
+    assert 'X-Forwarded-Context: /python-http-port54321\n' in s
+    assert 'X-Proxycontextpath: /python-http-port54321\n' in s
+
+    direct = request_get(54321, '/ghi', TOKEN)
+    assert direct.code == 200
+
+
+def test_server_proxy_port_non_absolute():
+    r = request_get(PORT, '/proxy/54321/jkl', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /jkl?token=')
+    assert 'X-Forwarded-Context: /proxy/54321\n' in s
+    assert 'X-Proxycontextpath: /proxy/54321\n' in s
+
+
+def test_server_proxy_port_absolute():
+    r = request_get(PORT, '/proxy/absolute/54321/nmo', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /proxy/absolute/54321/nmo?token=')
+    assert 'X-Forwarded-Context' not in s
+    assert 'X-Proxycontextpath' not in s


### PR DESCRIPTION
Port can be specified for servers, e.g. to listen on port 54321 instead of a random port
```python
python-http-port54321': {
    'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
    'port': 54321,
}
```
Closes https://github.com/jupyterhub/jupyter-server-proxy/issues/87