### PR TITLE
Clean up callback hell, some general typescript stuff

### DIFF
--- a/jupyterlab-server-proxy/src/index.ts
+++ b/jupyterlab-server-proxy/src/index.ts
@@ -1,36 +1,29 @@
-import { JupyterLab, JupyterLabPlugin } from '@jupyterlab/application'; 
+import { JupyterLab, JupyterLabPlugin } from '@jupyterlab/application';
+import { CommandRegistry } from '@phosphor/commands';
 import { ILauncher } from '@jupyterlab/launcher';
 import { PageConfig } from '@jupyterlab/coreutils';
 
 import '../style/index.css';
 
-
-function addLauncherEntries(serverData: any, launcher: ILauncher, app: JupyterLab) {
-    for (let server_process of serverData.server_processes) {
-
-      if (!server_process.launcher_entry.enabled) {
-        continue;
-      }
-
-      let commandId = 'server-proxy:' + server_process.name;
-
-      app.commands.addCommand(commandId, {
-        label: server_process.launcher_entry.title,
-        execute: () => {
-          let launch_url = PageConfig.getBaseUrl() + server_process.name + '/';
-          window.open(launch_url, '_blank');
-        }
-      });
-      let command : ILauncher.IItemOptions = {
-        command: commandId,
-        category: 'Notebook'
-      };
-      if (server_process.launcher_entry.icon_url) {
-        command.kernelIconUrl =  server_process.launcher_entry.icon_url;
-      }
-      launcher.add(command);
-    }
+/**
+ * JSON response expected from /server-proxy/servers-info/
+ */
+export interface ServersInfo {
+  server_processes: Server[];
 }
+
+/**
+ * JSON Proxy Server entry
+ */
+export interface Server {
+  name: string;
+  launcher_entry: {
+    enabled: boolean;
+    title: string;
+    icon_url?: string;
+  }
+}
+
 /**
  * Initialization data for the jupyterlab-server-proxy extension.
  */
@@ -38,20 +31,53 @@ const extension: JupyterLabPlugin<void> = {
   id: 'jupyterlab-server-proxy',
   autoStart: true,
   requires: [ILauncher],
-  activate: (app: JupyterLab, launcher: ILauncher) => {
-    // FIXME: What the callback hell is this
-    fetch(PageConfig.getBaseUrl() + 'server-proxy/servers-info').then(
-      response => {
-        if (!response.ok) {
-          console.log('Fetching metadata about registered failed. Make sure jupyter-server-proxy is installed');
-          console.log(response);
-        } else {
-          response.json().then(data => addLauncherEntries(data, launcher, app))
-        }
-
-      }
-    )
+  activate: async (app: JupyterLab, launcher: ILauncher) => {
+    const response = await fetch(PageConfig.getBaseUrl() + 'server-proxy/servers-info/');
+    if (!response.ok) {
+      console.warn('Fetching metadata about registered services failed.')
+      console.info('Make sure jupyter-server-proxy is installed');
+      console.debug(response);
+    } else {
+      addLauncherEntries(await response.json(), launcher, app.commands);
+    }
   }
 };
 
 export default extension;
+
+/**
+ * Add JupyterLab commands and Launcher cards for server proxies
+ */
+function addLauncherEntries(
+  serverData: ServersInfo,
+  launcher: ILauncher,
+  commands: CommandRegistry
+) {
+  const style = document.createElement('style');
+  document.head.appendChild(style);
+
+  for (const { name, launcher_entry } of serverData.server_processes) {
+    const { icon_url, enabled, title } = launcher_entry;
+
+    if (!enabled) {
+      continue;
+    }
+
+    const command = `server-proxy:${name}`;
+
+    const commandOptions: CommandRegistry.ICommandOptions = {
+      label: title,
+      execute: () => {
+        window.open(PageConfig.getBaseUrl() + name + '/', '_blank');
+      },
+    };
+
+    if (icon_url) {
+      commandOptions.iconClass = `jp-ServerProxy-icon-${name}`;
+      style.textContent += `.${commandOptions.iconClass} {background-image: url(${icon_url});}`;
+    }
+
+    commands.addCommand(command, commandOptions);
+    launcher.add({ command, category: 'Notebook' });
+  }
+}


### PR DESCRIPTION
Read the callback comment in the labextension and cracked up. Here's some changes:
- make `activate` async so it at least _reads_ better (though the generated code is still pretty weird, it's much better than it used to be)
- type the JSON coming back from the server
- clean up some deep nesting with destructuring

Happy to rework any of this!