### PR TITLE
Package the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_files = LICENSE


### PR DESCRIPTION
Make sure the license file is packaged in Python packages for end-user inspection.