### PR TITLE
Add /proxy/absolute/<port> to arbitrary-ports.rst

### DIFF
--- a/docs/arbitrary-ports.rst
+++ b/docs/arbitrary-ports.rst
@@ -6,8 +6,14 @@ Accessing Arbitrary Ports
 
 If you already have a server running on localhost listening on
 a port, you can access it through the notebook at
-``<notebook-base>/proxy/<port>``. This works for all ports listening
-on the local machine.
+``<notebook-base>/proxy/<port>``.
+The URL will be rewritten to remove the above prefix.
+
+You can disable URL rewriting by using
+``<notebook-base>/proxy/absolute/<port>`` so your server will receive the full
+URL in the request.
+
+This works for all ports listening on the local machine.
 
 With JupyterHub
 ===============


### PR DESCRIPTION
Whilst answering https://github.com/jupyterhub/jupyter-server-proxy/issues/116 I realised `/proxy/absolute/<port>` is missing from the docs.