### PR TITLE
WebsocketHandler.get is async

### DIFF
--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -93,7 +93,7 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
         if self.request.headers.get("Upgrade", "").lower() != 'websocket':
             return await self.http_get(*args, **kwargs)
         else:
-            awwait maybe_future(super().get(*args, **kwargs))
+            await maybe_future(super().get(*args, **kwargs))
 
 
 def setup_handlers(web_app):

--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -85,8 +85,7 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
     async def get(self, *args, **kwargs):
         if self.request.headers.get("Upgrade", "").lower() != 'websocket':
             return await self.http_get(*args, **kwargs)
-        # super get is not async
-        super().get(*args, **kwargs)
+        await super().get(*args, **kwargs)
 
 
 

--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -85,7 +85,10 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
     async def get(self, *args, **kwargs):
         if self.request.headers.get("Upgrade", "").lower() != 'websocket':
             return await self.http_get(*args, **kwargs)
-        await super().get(*args, **kwargs)
+        else:
+            result = super().get(*args, **kwargs)
+            if inspect.isawaitable(result):
+                await result
 
 
 

--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -14,6 +14,13 @@ from tornado import gen, web, httpclient, httputil, process, websocket, ioloop, 
 from notebook.utils import url_path_join
 from notebook.base.handlers import IPythonHandler, utcnow
 
+try:
+    # Tornado 6.0 deprecated its `maybe_future` function so `notebook` made their own.
+    # See: https://github.com/jupyter/notebook/pull/4453
+    from notebook.utils import maybe_future
+except ImportError:
+    # We can't find it in `notebook` then we should be able to find it in Tornado
+    from tornado.gen import maybe_future
 
 
 class PingableWSClientConnection(websocket.WebSocketClientConnection):
@@ -86,10 +93,7 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
         if self.request.headers.get("Upgrade", "").lower() != 'websocket':
             return await self.http_get(*args, **kwargs)
         else:
-            result = super().get(*args, **kwargs)
-            if inspect.isawaitable(result):
-                await result
-
+            awwait maybe_future(super().get(*args, **kwargs))
 
 
 def setup_handlers(web_app):


### PR DESCRIPTION
As of Tornado v6.0.2 some methods were converted to be async/await capable. See commit:

https://github.com/tornadoweb/tornado/commit/e69becbf8c994be5bfa6584ef72df594b27934b5

Closes: https://github.com/jupyterhub/jupyter-server-proxy/issues/39