### PR TITLE
Allow for other hosts than `localhost` to be proxied.

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -35,11 +35,42 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
     used directly as a means of overriding CORS. This presents significant
     security risks, and could allow arbitrary remote code access. Instead, it is
     meant to be subclassed and used for proxying URLs from trusted sources.
+
+    Subclasses should implement open, http_get, post, put, delete, head, patch,
+    and options.
     """
     def __init__(self, *args, **kwargs):
         self.proxy_base = ''
         self.absolute_url = kwargs.pop('absolute_url', False)
         super().__init__(*args, **kwargs)
+
+    # Support all the methods that torando does by default except for GET which
+    # is passed to WebSocketHandlerMixin and then to WebSocketHandler.
+
+    async def open(self, port, proxied_path):
+        raise NotImplementedError('Subclasses of ProxyHandler should implement open')
+
+    async def http_get(self, host, port, proxy_path=''):
+        '''Our non-websocket GET.'''
+        raise NotImplementedError('Subclasses of ProxyHandler should implement http_get')
+
+    def post(self, host, port, proxy_path=''):
+        raise NotImplementedError('Subclasses of ProxyHandler should implement this post')
+
+    def put(self, port, proxy_path=''):
+        raise NotImplementedError('Subclasses of ProxyHandler should implement this put')
+
+    def delete(self, host, port, proxy_path=''):
+        raise NotImplementedError('Subclasses of ProxyHandler should implement delete')
+
+    def head(self, host, port, proxy_path=''):
+        raise NotImplementedError('Subclasses of ProxyHandler should implement head')
+
+    def patch(self, host, port, proxy_path=''):
+        raise NotImplementedError('Subclasses of ProxyHandler should implement patch')
+
+    def options(self, host, port, proxy_path=''):
+        raise NotImplementedError('Subclasses of ProxyHandler should implement options')
 
     def on_message(self, message):
         """
@@ -245,31 +276,6 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         '''A dictionary of options to be used when constructing
         a tornado.httpclient.HTTPRequest instance for the proxy request.'''
         return dict(follow_redirects=False)
-
-    # Support all the methods that torando does by default except for GET which
-    # is passed to WebSocketHandlerMixin and then to WebSocketHandler.
-
-    async def http_get(self, host, port, proxy_path=''):
-        '''Our non-websocket GET.'''
-        return await self.proxy(host, port, proxy_path)
-
-    def post(self, host, port, proxy_path=''):
-        return self.proxy(host, port, proxy_path)
-
-    def put(self, port, proxy_path=''):
-        return self.proxy(host, port, proxy_path)
-
-    def delete(self, host, port, proxy_path=''):
-        return self.proxy(host, port, proxy_path)
-
-    def head(self, host, port, proxy_path=''):
-        return self.proxy(host, port, proxy_path)
-
-    def patch(self, host, port, proxy_path=''):
-        return self.proxy(host, port, proxy_path)
-
-    def options(self, host, port, proxy_path=''):
-        return self.proxy(host, port, proxy_path)
 
     def check_xsrf_cookie(self):
         '''

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -11,4 +11,8 @@ c.ServerProxy.servers = {
         'port': 54321,
     },
 }
+
+import sys
+sys.path.append('./tests/resources')
+c.NotebookApp.nbserver_extensions = { 'proxyextension': True }
 #c.Application.log_level = 'DEBUG'

--- a/tests/resources/proxyextension.py
+++ b/tests/resources/proxyextension.py
@@ -1,0 +1,47 @@
+from jupyter_server_proxy.handlers import ProxyHandler
+from notebook.utils import url_path_join
+
+class NewHandler(ProxyHandler):
+    async def http_get(self):
+        return await self.proxy()
+
+    async def open(self):
+        host = '127.0.0.1'
+        port = 54321
+        return await super().proxy_open(host, port)
+
+    def post(self):
+        return self.proxy()
+
+    def put(self):
+        return self.proxy()
+
+    def delete(self):
+        return self.proxy()
+
+    def head(self):
+        return self.proxy()
+
+    def patch(self):
+        return self.proxy()
+
+    def options(self):
+        return self.proxy()
+
+    def proxy(self):
+        host = '127.0.0.1'
+        port = 54321
+        proxied_path = ''
+        return super().proxy(host, port, proxied_path)
+
+
+def _jupyter_server_extension_paths():
+    return [{"module": "dask_labextension"}]
+
+
+def load_jupyter_server_extension(nb_server_app):
+    web_app = nb_server_app.web_app
+    base_url = web_app.settings["base_url"]
+    proxy_path = url_path_join(base_url, "newproxy/" + "?")
+    handlers = [(proxy_path, NewHandler)]
+    web_app.add_handlers(".*$", handlers)

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -5,8 +5,8 @@ PORT = os.getenv('TEST_PORT', 8888)
 TOKEN = os.getenv('JUPYTER_TOKEN', 'secret')
 
 
-def request_get(port, path, token):
-    h = HTTPConnection('localhost', port, 10)
+def request_get(port, path, token, host='localhost'):
+    h = HTTPConnection(host, port, 10)
     h.request('GET', '{}?token={}'.format(path, token))
     return h.getresponse()
 
@@ -57,3 +57,7 @@ def test_server_proxy_port_absolute():
     assert s.startswith('GET /proxy/absolute/54321/nmo?token=')
     assert 'X-Forwarded-Context' not in s
     assert 'X-Proxycontextpath' not in s
+
+def test_server_proxy_remote():
+    r = request_get(PORT, '/newproxy', TOKEN, host='127.0.0.1')
+    assert r.code == 200


### PR DESCRIPTION
Finishes the work needed for #70, dask/dask-labextension#58.

This allows the developer to specify a non-localhost URI to be proxied. It should be a non-breaking change for users to `LocalProxyHandler`. It seems to work well in my testing, but @yuvipanda and @ryanlovett have a much better idea of the range of places where `jupyter-server-proxy` are deployed.