### PR TITLE
Add code-server-traitlet example.

### DIFF
--- a/contrib/code-server-traitlet/README.md
+++ b/contrib/code-server-traitlet/README.md
@@ -1,0 +1,5 @@
+## code-server-traitlet
+
+Create a code-server launcher [via traitlet](https://jupyter-server-proxy.readthedocs.io/en/latest/server-process.html#specifying-config-via-traitlets).
+
+Via https://github.com/betatim/vscode-binder.

--- a/contrib/code-server-traitlet/jupyter_notebook_config.py
+++ b/contrib/code-server-traitlet/jupyter_notebook_config.py
@@ -1,0 +1,15 @@
+c.ServerProxy.servers = {
+  'code-server': {
+    'command': [
+      'code-server',
+        '--no-auth',
+        '--disable-telemetry',
+        '--allow-http',
+        '--port={port}'
+    ],
+    'timeout': 20,
+    'launcher_entry': {
+      'title': 'VS Code'
+    }
+  }
+}


### PR DESCRIPTION
Traitlet derivative of @betatim's vscode-binder.