### PR TITLE
Optionally map requested → proxied paths

### DIFF
--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -90,6 +90,13 @@ pairs.
      automatically select an unused port.
 
 
+#. **mappath**
+
+     Map request paths to proxied paths.
+     Either a dictionary of request paths to proxied paths,
+     or a callable that takes parameter ``path`` and returns the proxied path.
+
+
 #. **launcher_entry**
 
    A dictionary with options on if / how an entry in the classic Jupyter Notebook

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -9,7 +9,7 @@ import pkg_resources
 from collections import namedtuple
 from .utils import call_with_asked_args
 
-def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port, indexpage):
+def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port, mappath):
     """
     Create a SuperviseAndProxyHandler subclass with given parameters
     """
@@ -21,7 +21,7 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url,
             self.proxy_base = name
             self.absolute_url = absolute_url
             self.requested_port = port
-            self.indexpage = indexpage
+            self.mappath = mappath
 
         @property
         def process_args(self):
@@ -83,7 +83,7 @@ def make_handlers(base_url, server_processes):
             sp.timeout,
             sp.absolute_url,
             sp.port,
-            sp.indexpage,
+            sp.mappath,
         )
         handlers.append((
             ujoin(base_url, sp.name, r'(.*)'), handler, dict(state={}),
@@ -95,7 +95,7 @@ def make_handlers(base_url, server_processes):
 
 LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title'])
 ServerProcess = namedtuple('ServerProcess', [
-    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'indexpage', 'launcher_entry'])
+    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'mappath', 'launcher_entry'])
 
 def make_server_process(name, server_process_config):
     le = server_process_config.get('launcher_entry', {})
@@ -106,7 +106,7 @@ def make_server_process(name, server_process_config):
         timeout=server_process_config.get('timeout', 5),
         absolute_url=server_process_config.get('absolute_url', False),
         port=server_process_config.get('port', 0),
-        indexpage=server_process_config.get('indexpage', ''),
+        mappath=server_process_config.get('mappath', ''),
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),
             icon_path=le.get('icon_path'),
@@ -147,10 +147,10 @@ class ServerProxy(Configurable):
           port
             Set the port that the service will listen on. The default is to automatically select an unused port.
 
-          indexpage
-            If the root of the service is requested return this page instead.
-            This is often referred to in web-server configurations as the index
-            page.
+          mappath
+            Map request paths to proxied paths.
+            Either a dictionary of request paths to proxied paths,
+            or a callable that takes parameter ``path`` and returns the proxied path.
 
           launcher_entry
             A dictionary of various options for entries in classic notebook / jupyterlab launchers.

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -9,7 +9,7 @@ import pkg_resources
 from collections import namedtuple
 from .utils import call_with_asked_args
 
-def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port):
+def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port, indexpage):
     """
     Create a SuperviseAndProxyHandler subclass with given parameters
     """
@@ -21,6 +21,7 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url,
             self.proxy_base = name
             self.absolute_url = absolute_url
             self.requested_port = port
+            self.indexpage = indexpage
 
         @property
         def process_args(self):
@@ -82,6 +83,7 @@ def make_handlers(base_url, server_processes):
             sp.timeout,
             sp.absolute_url,
             sp.port,
+            sp.indexpage,
         )
         handlers.append((
             ujoin(base_url, sp.name, r'(.*)'), handler, dict(state={}),
@@ -93,7 +95,7 @@ def make_handlers(base_url, server_processes):
 
 LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title'])
 ServerProcess = namedtuple('ServerProcess', [
-    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'launcher_entry'])
+    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'indexpage', 'launcher_entry'])
 
 def make_server_process(name, server_process_config):
     le = server_process_config.get('launcher_entry', {})
@@ -104,6 +106,7 @@ def make_server_process(name, server_process_config):
         timeout=server_process_config.get('timeout', 5),
         absolute_url=server_process_config.get('absolute_url', False),
         port=server_process_config.get('port', 0),
+        indexpage=server_process_config.get('indexpage', ''),
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),
             icon_path=le.get('icon_path'),
@@ -143,6 +146,11 @@ class ServerProxy(Configurable):
 
           port
             Set the port that the service will listen on. The default is to automatically select an unused port.
+
+          indexpage
+            If the root of the service is requested return this page instead.
+            This is often referred to in web-server configurations as the index
+            page.
 
           launcher_entry
             A dictionary of various options for entries in classic notebook / jupyterlab launchers.

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -106,7 +106,7 @@ def make_server_process(name, server_process_config):
         timeout=server_process_config.get('timeout', 5),
         absolute_url=server_process_config.get('absolute_url', False),
         port=server_process_config.get('port', 0),
-        mappath=server_process_config.get('mappath', ''),
+        mappath=server_process_config.get('mappath', {}),
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),
             icon_path=le.get('icon_path'),

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -44,7 +44,7 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         self.absolute_url = kwargs.pop('absolute_url', False)
         super().__init__(*args, **kwargs)
 
-    # Support all the methods that torando does by default except for GET which
+    # Support all the methods that tornado does by default except for GET which
     # is passed to WebSocketHandlerMixin and then to WebSocketHandler.
 
     async def open(self, port, proxied_path):

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -340,6 +340,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
 
     def __init__(self, *args, **kwargs):
         self.requested_port = 0
+        self.indexpage = ''
         super().__init__(*args, **kwargs)
 
     def initialize(self, state):
@@ -435,6 +436,8 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
     async def proxy(self, port, path):
         if not path.startswith('/'):
             path = '/' + path
+        if self.indexpage and (path == '/' or path.startswith == '/?'):
+            path = '/' + self.indexpage + path[1:]
 
         await self.ensure_process()
 

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -1,3 +1,7 @@
+def mappathf(path):
+    p = path + 'mapped'
+    return p
+
 c.ServerProxy.servers = {
     'python-http': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
@@ -10,9 +14,15 @@ c.ServerProxy.servers = {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
         'port': 54321,
     },
-    'python-http-indexpage': {
+    'python-http-mappath': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
-        'indexpage': 'index.html',
+        'mappath': {
+            '/': '/index.html',
+        }
+    },
+    'python-http-mappathf': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'mappath': mappathf,
     },
 }
 

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -10,6 +10,10 @@ c.ServerProxy.servers = {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
         'port': 54321,
     },
+    'python-http-indexpage': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'indexpage': 'index.html',
+    },
 }
 
 import sys

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -58,6 +58,25 @@ def test_server_proxy_port_absolute():
     assert 'X-Forwarded-Context' not in s
     assert 'X-Proxycontextpath' not in s
 
+
+def test_server_proxy_indexpage_index():
+    r = request_get(PORT, '/python-http-indexpage/', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /index.html?token=')
+    assert 'X-Forwarded-Context: /python-http-indexpage\n' in s
+    assert 'X-Proxycontextpath: /python-http-indexpage\n' in s
+
+
+def test_server_proxy_indexpage_other():
+    r = request_get(PORT, '/python-http-indexpage/pqr', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /pqr?token=')
+    assert 'X-Forwarded-Context: /python-http-indexpage\n' in s
+    assert 'X-Proxycontextpath: /python-http-indexpage\n' in s
+
+
 def test_server_proxy_remote():
     r = request_get(PORT, '/newproxy', TOKEN, host='127.0.0.1')
     assert r.code == 200


### PR DESCRIPTION
Most webservers can be configured to serve a page if a directory `/` is accessed, or to redirect to a different path. This PR adds this functionality to jupyter-proxy-server.

For example, when using noVNC the default page is a directory listing. With this PR you can map `/` to `vnc_lite.html`.

E.g. https://gist.github.com/manics/7d1f4b76ce06c2bb07db88e3496a1561