### PR TITLE
Move npm package to jupyterlab org

### DIFF
--- a/jupyterlab-server-proxy/README.md
+++ b/jupyterlab-server-proxy/README.md
@@ -10,7 +10,7 @@ Launcher icons for proxied applications
 ## Installation
 
 ```bash
-jupyter labextension install jupyterlab-server-proxy
+jupyter labextension install @jupyterlab/server-proxy
 ```
 
 ## Development

--- a/jupyterlab-server-proxy/package.json
+++ b/jupyterlab-server-proxy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jupyterlab-server-proxy",
+  "name": "@jupyterlab/server-proxy",
   "version": "2.0.0",
   "description": "Launcher icons for proxied applications",
   "keywords": [


### PR DESCRIPTION
This allows JupyterLab maintainers to make the npm releases.