### PR TITLE
Replace icon_url with icon_path in __init__.py.

### DIFF
--- a/contrib/template/{{cookiecutter.project_name}}/jupyter_{{cookiecutter.project_name}}_proxy/__init__.py
+++ b/contrib/template/{{cookiecutter.project_name}}/jupyter_{{cookiecutter.project_name}}_proxy/__init__.py
@@ -12,6 +12,6 @@ def setup_{{cookiecutter.project_name}}():
         'environment': {},
         'launcher_entry': {
             'title': '{{cookiecutter.project_name}}',
-            'icon_url': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'icons', '{{cookiecutter.project_name}}.svg')
+            'icon_path': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'icons', '{{cookiecutter.project_name}}.svg')
         }
     }


### PR DESCRIPTION
In line with the documentation the correct key for the path of the icons folder in the launcher_entry is icon_path and not icon_url. See https://jupyter-server-proxy.readthedocs.io/en/latest/server-process.html

This PR is a solution for issue #162 