### PR TITLE
Support usage of JupyterLab 2.0.0

### DIFF
--- a/jupyterlab-server-proxy/package.json
+++ b/jupyterlab-server-proxy/package.json
@@ -30,12 +30,12 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^1.0.0",
-    "@jupyterlab/launcher": "^1.0.0"
+    "@jupyterlab/application": "^1.0.0 || ^2.0.0",
+    "@jupyterlab/launcher": "^1.0.0 || ^2.0.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",
-    "typescript": "~3.5.1"
+    "typescript": "~3.7.0"
   },
   "jupyterlab": {
     "extension": true

--- a/jupyterlab-server-proxy/package.json
+++ b/jupyterlab-server-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/server-proxy",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Launcher icons for proxied applications",
   "keywords": [
     "jupyter",

--- a/jupyterlab-server-proxy/tsconfig.json
+++ b/jupyterlab-server-proxy/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "declaration": true,
     "lib": ["es2015", "dom"],
     "module": "commonjs",


### PR DESCRIPTION
Fixes #173

At least, I think this fixes #173, I have not verified the functionality but only verified I could build it without failures after bumping it. Also, note the comment in the second commit for an explanation about the change in tsconfig.json