### PR TITLE
Quote proxied_path to make it a safe URL (fixes #138)

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -140,7 +140,7 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         else:
             client_path = proxied_path
 
-        client_path = quote(client_path)
+        # client_path = quote(client_path)
 
         client_uri = '{protocol}://{host}:{port}{path}'.format(
             protocol=protocol,

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -139,7 +139,7 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
             client_path = url_path_join(context_path, proxied_path)
         else:
             client_path = proxied_path
-        
+
         client_path = quote(client_path)
 
         client_uri = '{protocol}://{host}:{port}{path}'.format(

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -139,6 +139,8 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
             client_path = url_path_join(context_path, proxied_path)
         else:
             client_path = proxied_path
+        
+        client_path = quote(client_path)
 
         client_uri = '{protocol}://{host}:{port}{path}'.format(
             protocol=protocol,
@@ -155,7 +157,7 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
 
         headers = self.proxy_request_headers()
 
-        client_uri = self.get_client_uri('http', host, port, quote(proxied_path))
+        client_uri = self.get_client_uri('http', host, port, proxied_path)
         # Some applications check X-Forwarded-Context and X-ProxyContextPath
         # headers to see if and where they are being proxied from.
         if not self.absolute_url:

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -140,7 +140,7 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         else:
             client_path = proxied_path
 
-        # client_path = quote(client_path)
+        client_path = quote(client_path)
 
         client_uri = '{protocol}://{host}:{port}{path}'.format(
             protocol=protocol,

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -7,7 +7,7 @@ Some original inspiration from https://github.com/senko/tornado-proxy
 import inspect
 import socket
 import os
-from urllib.parse import urlunparse, urlparse
+from urllib.parse import urlunparse, urlparse, quote
 import aiohttp
 from asyncio import Lock
 
@@ -155,7 +155,7 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
 
         headers = self.proxy_request_headers()
 
-        client_uri = self.get_client_uri('http', host, port, proxied_path)
+        client_uri = self.get_client_uri('http', host, port, quote(proxied_path))
         # Some applications check X-Forwarded-Context and X-ProxyContextPath
         # headers to see if and where they are being proxied from.
         if not self.absolute_url:

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -18,11 +18,11 @@ def request_get(port, path, token, host='localhost'):
 
 
 def test_server_proxy_url_encoding():
-    special_path = 'Hellö Wörld 🎉你好世界@±¥'
-    test_url = quote('/python-http/' + special_path)
+    special_path = quote('Hellö Wörld 🎉你好世界@±¥')
+    test_url = '/python-http/' + special_path
     r = request_get(PORT, test_url, TOKEN)
     assert r.code == 200
-    s = r.read().decode('utf-8')
+    s = r.read().decode('ascii')
     assert s.startswith('GET /{}?token='.format(special_path))
 
 

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -16,6 +16,13 @@ def request_get(port, path, token, host='localhost'):
     return h.getresponse()
 
 
+def test_server_proxy_url_encoding():
+    r = request_get(PORT, '/python-http/Hellö Wörld 🎉你好世界@±¥', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('utf-8')
+    assert s.startswith('GET /Hellö Wörld 🎉你好世界@±¥?token=')
+
+
 def test_server_proxy_non_absolute():
     r = request_get(PORT, '/python-http/abc', TOKEN)
     assert r.code == 200

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -1,5 +1,6 @@
 import os
 from http.client import HTTPConnection
+from urllib.parse import quote
 import pytest
 
 PORT = os.getenv('TEST_PORT', 8888)
@@ -17,10 +18,12 @@ def request_get(port, path, token, host='localhost'):
 
 
 def test_server_proxy_url_encoding():
-    r = request_get(PORT, '/python-http/Hellö Wörld 🎉你好世界@±¥', TOKEN)
+    special_path = 'Hellö Wörld 🎉你好世界@±¥'
+    test_url = quote('/python-http/' + special_path)
+    r = request_get(PORT, test_url, TOKEN)
     assert r.code == 200
     s = r.read().decode('utf-8')
-    assert s.startswith('GET /Hellö Wörld 🎉你好世界@±¥?token=')
+    assert s.startswith('GET /{}?token='.format(special_path))
 
 
 def test_server_proxy_non_absolute():


### PR DESCRIPTION
Currently if there is special character in the proxied path, it failed with error, e.g:
```bash
[E 16:28:29.202 NotebookApp] Uncaught exception GET /myservice/static/Desktop/Screenshot%202020-03-10%20at%2021.50.46.png (127.0.0.1)
    HTTPServerRequest(protocol='http', host='127.0.0.1:9527', method='GET', uri='/myservice/static/Desktop/Screenshot%202020-03-10%20at%2021.50.46.png', version='HTTP/1.1', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File "/Users/me/miniconda3/envs/myservice/lib/python3.6/site-packages/tornado/web.py", line 1703, in _execute
        result = await result
      File "/Users/me/miniconda3/envs/myservice/lib/python3.6/site-packages/jupyter_server_proxy/websocket.py", line 96, in get
        return await self.http_get(*args, **kwargs)
      File "/Users/me/miniconda3/envs/myservice/lib/python3.6/site-packages/jupyter_server_proxy/handlers.py", line 510, in http_get
        return await self.proxy(self.port, path)
      File "/Users/me/miniconda3/envs/myservice/lib/python3.6/site-packages/jupyter_server_proxy/handlers.py", line 503, in proxy
        return await super().proxy(self.port, path)
      File "/Users/me/miniconda3/envs/myservice/lib/python3.6/site-packages/jupyter_server_proxy/handlers.py", line 213, in proxy
        response = await client.fetch(req, raise_error=False)
    tornado.simple_httpclient.HTTPStreamClosedError: Stream closed
```

This is a fix for that by quote the proxied path and make it safe.