### PR TITLE
Capture request timeout error and increase the timeout value

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -217,6 +217,10 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
         try:
             response = await client.fetch(req, raise_error=False)
         except httpclient.HTTPError as err:
+            # We need to capture the timeout error even with raise_error=False,
+            # because it only affects the HTTPError raised when a non-200 response 
+            # code is used, instead of suppressing all errors.
+            # Ref: https://www.tornadoweb.org/en/stable/httpclient.html#tornado.httpclient.AsyncHTTPClient.fetch
             if err.code == 599:
                 self._record_activity()
                 self.set_status(599)

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -308,7 +308,7 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
     def proxy_request_options(self):
         '''A dictionary of options to be used when constructing
         a tornado.httpclient.HTTPRequest instance for the proxy request.'''
-        return dict(follow_redirects=False)
+        return dict(follow_redirects=False, request_timeout=75)
 
     def check_xsrf_cookie(self):
         '''

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -316,7 +316,7 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
     def proxy_request_options(self):
         '''A dictionary of options to be used when constructing
         a tornado.httpclient.HTTPRequest instance for the proxy request.'''
-        return dict(follow_redirects=False, request_timeout=75)
+        return dict(follow_redirects=False, request_timeout=75.0)
 
     def check_xsrf_cookie(self):
         '''

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -319,7 +319,7 @@ class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
     def proxy_request_options(self):
         '''A dictionary of options to be used when constructing
         a tornado.httpclient.HTTPRequest instance for the proxy request.'''
-        return dict(follow_redirects=False, connect_timeout=250, request_timeout=300.0)
+        return dict(follow_redirects=False, connect_timeout=250.0, request_timeout=300.0)
 
     def check_xsrf_cookie(self):
         '''


### PR DESCRIPTION
This PR aims to fix https://github.com/jupyterhub/jupyter-server-proxy/issues/182, it:
1. Increase the `connect_timeout=250.0, request_timeout=300.0` (both defaults to 20s) (these two values are used as default for FireFox).
2. Capture the timeout error, return `599: Timeout during request` rather than `500: Internal Server Error`.