### PR TITLE
Fix expected type of ServerProxy command callable

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -135,7 +135,7 @@ class ServerProxy(Configurable):
             The optional template arguments {{port}} and {{base_url}} will be substituted with the
             port the process should listen on and the base-url of the notebook.
 
-            Could also be a callable. It should return a dictionary.
+            Could also be a callable. It should return a list.
 
           environment
             A dictionary of environment variable mappings. {{port}} and {{base_url}} will be


### PR DESCRIPTION
ServerProxy command if callable should return a list, while in the docstring it says it should return a dictionary.