### PR TITLE
Set list item class as sever_process.name in tree.js

### DIFF
--- a/jupyter_server_proxy/static/tree.js
+++ b/jupyter_server_proxy/static/tree.js
@@ -30,7 +30,7 @@ define(['jquery', 'base/js/namespace', 'base/js/utils'], function($, Jupyter, ut
                 /* create our list item */
                 var $entry_container = $('<li>')
                     .attr('role', 'presentation')
-                    .addClass('new-rstudio');
+                    .addClass('new-' + server_process.name);
 
                 /* create our list item's link */
                 var $entry_link = $('<a>')


### PR DESCRIPTION
All server process entries shared the same class named after rstudio.