### PR TITLE
In JupyterLab, add proxy to command registry even if launcher entry is disabled

### DIFF
--- a/jupyterlab-server-proxy/src/index.ts
+++ b/jupyterlab-server-proxy/src/index.ts
@@ -7,11 +7,6 @@ import '../style/index.css';
 
 function addLauncherEntries(serverData: any, launcher: ILauncher, app: JupyterFrontEnd) {
     for (let server_process of serverData.server_processes) {
-
-      if (!server_process.launcher_entry.enabled) {
-        continue;
-      }
-
       let commandId = 'server-proxy:' + server_process.name;
 
       app.commands.addCommand(commandId, {
@@ -21,14 +16,19 @@ function addLauncherEntries(serverData: any, launcher: ILauncher, app: JupyterFr
           window.open(launch_url, '_blank');
         }
       });
-      let command : ILauncher.IItemOptions = {
+
+      if (!server_process.launcher_entry.enabled) {
+        continue;
+      }
+
+      let launcher_item : ILauncher.IItemOptions = {
         command: commandId,
         category: 'Notebook'
       };
       if (server_process.launcher_entry.icon_url) {
-        command.kernelIconUrl =  server_process.launcher_entry.icon_url;
+        launcher_item.kernelIconUrl =  server_process.launcher_entry.icon_url;
       }
-      launcher.add(command);
+      launcher.add(launcher_item);
     }
 }
 /**


### PR DESCRIPTION
Currently, when a server proxy launcher is entry is not enabled in the configuration file, the server proxy command is not added to the command registry. Other extensions could be interested in handling the launcher entries while jupyterlab-server-proxy handles the registration of the commands.

This is the case for [jupyterlab-lmod extension](https://github.com/cmd-ntrf/jupyter-lmod), where we want to show the launcher button only when the corresponding software module is loaded. I have made a short video of the workflow https://youtu.be/EQOGcoK2mSE. In order to achieve what is demonstrated, I had to copy the code for the command creation and launcher entry adding from jupyter-server-proxy in jupyter-lmod.

