### PR TITLE
Use more common Unicode arrow

### DIFF
--- a/jupyterlab-server-proxy/src/index.ts
+++ b/jupyterlab-server-proxy/src/index.ts
@@ -88,7 +88,7 @@ async function activate(app: JupyterFrontEnd, launcher: ILauncher, restorer: ILa
       command: command,
       args: {
         url: url,
-        title: title + (newBrowserTab ? ' [🡕]': ''),
+        title: title + (newBrowserTab ? ' [↗]': ''),
         newBrowserTab: newBrowserTab,
         id: id
       },


### PR DESCRIPTION
The old character 🡕 is a relatively obscure sans-serif variant of the more standard arrow ↗, the later of which should have much better coverage.

This should solve #200.

If we want to do even better, several alternatives are available in [this SO question](https://stackoverflow.com/questions/1899772/new-window-icon-for-web-accessibility).