### PR TITLE
Add rewrite_response

### DIFF
--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -23,13 +23,19 @@ def _load_jupyter_server_extension(nbapp):
     base_url = nbapp.web_app.settings['base_url']
     serverproxy_config = ServerProxyConfig(parent=nbapp)
 
-    server_processes = [make_server_process(k, v) for k, v in serverproxy_config.servers.items()]
+    server_processes = [
+        make_server_process(name, server_process_config)
+        for name, server_process_config in serverproxy_config.servers.items()
+    ]
     server_processes += get_entrypoint_server_processes()
     server_handlers = make_handlers(base_url, server_processes)
     nbapp.web_app.add_handlers('.*', server_handlers)
 
-    # Set up default handler
-    setup_handlers(nbapp.web_app, serverproxy_config.host_allowlist)
+    # Set up default non-server handler
+    setup_handlers(
+        nbapp.web_app,
+        serverproxy_config.host_allowlist,
+    )
 
     icons = {}
     for sp in server_processes:
@@ -38,7 +44,7 @@ def _load_jupyter_server_extension(nbapp):
 
     nbapp.web_app.add_handlers('.*', [
         (ujoin(base_url, 'server-proxy/servers-info'), ServersInfoHandler, {'server_processes': server_processes}),
-        (ujoin(base_url, 'server-proxy/icon/(.*)'), IconHandler, {'icons': icons})
+        (ujoin(base_url, 'server-proxy/icon/(.*)'), IconHandler, {'icons': icons}),
     ])
 
 

--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -1,5 +1,5 @@
 from .handlers import setup_handlers
-from .config import ServerProxy, make_handlers, get_entrypoint_server_processes, make_server_process
+from .config import ServerProxy as ServerProxyConfig, make_handlers, get_entrypoint_server_processes, make_server_process
 from jupyter_server.utils import url_path_join as ujoin
 from .api import ServersInfoHandler, IconHandler
 
@@ -21,15 +21,15 @@ def _jupyter_nbextension_paths():
 def _load_jupyter_server_extension(nbapp):
     # Set up handlers picked up via config
     base_url = nbapp.web_app.settings['base_url']
-    serverproxy = ServerProxy(parent=nbapp)
+    serverproxy_config = ServerProxyConfig(parent=nbapp)
 
-    server_processes = [make_server_process(k, v) for k, v in serverproxy.servers.items()]
+    server_processes = [make_server_process(k, v) for k, v in serverproxy_config.servers.items()]
     server_processes += get_entrypoint_server_processes()
     server_handlers = make_handlers(base_url, server_processes)
     nbapp.web_app.add_handlers('.*', server_handlers)
 
     # Set up default handler
-    setup_handlers(nbapp.web_app, serverproxy.host_allowlist)
+    setup_handlers(nbapp.web_app, serverproxy_config.host_allowlist)
 
     icons = {}
     for sp in server_processes:

--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -24,17 +24,17 @@ def _load_jupyter_server_extension(nbapp):
     serverproxy_config = ServerProxyConfig(parent=nbapp)
 
     server_processes = [
-        make_server_process(name, server_process_config)
+        make_server_process(name, server_process_config, serverproxy_config)
         for name, server_process_config in serverproxy_config.servers.items()
     ]
-    server_processes += get_entrypoint_server_processes()
+    server_processes += get_entrypoint_server_processes(serverproxy_config)
     server_handlers = make_handlers(base_url, server_processes)
     nbapp.web_app.add_handlers('.*', server_handlers)
 
     # Set up default non-server handler
     setup_handlers(
         nbapp.web_app,
-        serverproxy_config.host_allowlist,
+        serverproxy_config,
     )
 
     icons = {}

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -77,8 +77,10 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url,
 def get_entrypoint_server_processes():
     sps = []
     for entry_point in pkg_resources.iter_entry_points('jupyter_serverproxy_servers'):
+        name = entry_point.name
+        server_process_config = entry_point.load()()
         sps.append(
-            make_server_process(entry_point.name, entry_point.load()())
+            make_server_process(name, server_process_config)
         )
     return sps
 
@@ -108,7 +110,9 @@ def make_handlers(base_url, server_processes):
 
 LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title', 'path_info'])
 ServerProcess = namedtuple('ServerProcess', [
-    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'mappath', 'launcher_entry', 'new_browser_tab', 'request_headers_override'])
+    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port',
+    'mappath', 'launcher_entry', 'new_browser_tab', 'request_headers_override',
+])
 
 def make_server_process(name, server_process_config):
     le = server_process_config.get('launcher_entry', {})
@@ -127,7 +131,7 @@ def make_server_process(name, server_process_config):
             path_info=le.get('path_info', name + "/")
         ),
         new_browser_tab=server_process_config.get('new_browser_tab', True),
-        request_headers_override=server_process_config.get('request_headers_override', {})
+        request_headers_override=server_process_config.get('request_headers_override', {}),
     )
 
 class ServerProxy(Configurable):

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -74,13 +74,13 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url,
     return _Proxy
 
 
-def get_entrypoint_server_processes():
+def get_entrypoint_server_processes(serverproxy_config):
     sps = []
     for entry_point in pkg_resources.iter_entry_points('jupyter_serverproxy_servers'):
         name = entry_point.name
         server_process_config = entry_point.load()()
         sps.append(
-            make_server_process(name, server_process_config)
+            make_server_process(name, server_process_config, serverproxy_config)
         )
     return sps
 
@@ -114,7 +114,7 @@ ServerProcess = namedtuple('ServerProcess', [
     'mappath', 'launcher_entry', 'new_browser_tab', 'request_headers_override',
 ])
 
-def make_server_process(name, server_process_config):
+def make_server_process(name, server_process_config, serverproxy_config):
     le = server_process_config.get('launcher_entry', {})
     return ServerProcess(
         name=name,

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -572,7 +572,6 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
 
 
 def setup_handlers(web_app, host_allowlist):
-    host_pattern = '.*$'
     web_app.add_handlers('.*', [
         (
             url_path_join(

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -571,7 +571,8 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
         return self.proxy(self.port, path)
 
 
-def setup_handlers(web_app, host_allowlist):
+def setup_handlers(web_app, serverproxy_config):
+    host_allowlist = serverproxy_config.host_allowlist
     web_app.add_handlers('.*', [
         (
             url_path_join(
@@ -598,7 +599,8 @@ def setup_handlers(web_app, host_allowlist):
         (
             url_path_join(
                 web_app.settings['base_url'],
-                r'/proxy/(\d+)(.*)'),
+                r'/proxy/(\d+)(.*)',
+            ),
             LocalProxyHandler,
             {
                 'absolute_url': False,

--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -94,7 +94,6 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
 
 
 def setup_handlers(web_app):
-    host_pattern = '.*$'
     web_app.add_handlers('.*', [
         (url_path_join(web_app.settings['base_url'], r'/proxy/(\d+)(.*)'), LocalProxyHandler)
     ])

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -5,6 +5,7 @@ def mappathf(path):
 c.ServerProxy.servers = {
     'python-http': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'rewrite_response': lambda host, port, path, response: response.body.replace(b"ciao", b"hello")
     },
     'python-http-abs': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
@@ -40,6 +41,9 @@ c.ServerProxy.servers = {
         'command': ['python3', './tests/resources/gzipserver.py', '{port}'],
     },
 }
+
+c.ServerProxy.non_service_rewrite_response = \
+    lambda host, port, path, response: response.body.replace(b"bar", b"foo")
 
 import sys
 sys.path.append('./tests/resources')

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -86,6 +86,13 @@ def test_server_proxy_hash_sign_encoding():
     assert s == ''
 
 
+def test_server_rewrite_response():
+    r = request_get(PORT, '/python-http/ciao-a-tutti', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /hello-a-tutti?token=')
+
+
 def test_server_proxy_non_absolute():
     r = request_get(PORT, '/python-http/abc', TOKEN)
     assert r.code == 200
@@ -151,6 +158,13 @@ def test_server_proxy_host_absolute():
     assert s.startswith('GET /proxy/absolute/127.0.0.1:54321/nmo?token=')
     assert 'X-Forwarded-Context' not in s
     assert 'X-Proxycontextpath' not in s
+
+def test_server_proxy_port_non_service_rewrite_response():
+    """Test that 'bar' is replaced by 'foo'."""
+    r = request_get(PORT, '/proxy/54321/baz-bar-foo', TOKEN)
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /baz-foo-foo?token=')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hey all, here's what I came up with to resolve #202.

I seem to have achieved my original goal, but there's quite a lot I'm dissatisfied about.

1. In order to be able to read the config in the appropriate spots, I ended up having to change the signatures of several functions. Will this cause breakage in other projects? Is there some better way which I didn't see?
2. I couldn't make my new `rewrite_response` function take just `response` as input without losing important information. Thus I modified my original specification, and `rewrite_response` is now a function of `host`, `port`, `path`, and `response`.
3. I had to implement a near-duplicate function `non_service_rewrite_response` to handle the `/proxy/` endpoint. In this case I'm skeptical of the `jupyter-server-proxy` design. Namely, I would find it more intuitive to first define a correspondence between "j-s-p server" objects and endpoints, and then implement the `/proxy/` endpoint as a "j-s-p server". Was it a conscious design decision not to do this, or is it just the way things evolved?
4. I would like to be able to intercept redirects, but if I'm not mistaken, redirects typically have no response body. Thus my `rewrite_response` won't be of any help here.
5. I couldn't figure out how to rebuild the docs.

I do think this PR is a step forward. Regarding the points above, would it make sense to address any quick fixes, merge, and then make issues for any outstanding points?