### PR TITLE
Add an Examples section to the documentation

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,15 @@
+.. _examples:
+
+========
+Examples
+========
+
+If you are looking for examples on how to configure ``jupyter-server-proxy``, you might want to check existing
+projects on GitHub, such as:
+
+- `jupyter-pgweb-proxy <https://github.com/illumidesk/jupyter-pgweb-proxy>`_: Run `pgweb <https://github.com/sosedoff/pgweb>`_ (cross-platform PostgreSQL client)
+- `jupyterserverproxy-openrefine <https://github.com/psychemedia/jupyterserverproxy-openrefine>`_: Run `OpenRefine <https://openrefine.org/>`_ (tool for working with messy data)
+- `mamba-navigator <https://github.com/mamba-org/mamba-navigator>`_: Run the Mamba Navigator (JupyterLab-based standalone application)
+
+Projects can also add the ``jupyter-server-proxy`` topic to the GitHub repository to make it more discoverable:
+`https://github.com/topics/jupyter-server-proxy <https://github.com/topics/jupyter-server-proxy>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,14 @@ for popular applications.
 Making and contributing a :ref:`new convenience package <convenience/new>`
 is very much appreciated.
 
+Examples
+========
+
+.. toctree::
+   :maxdepth: 1
+
+   examples
+
 
 Contributing
 ============


### PR DESCRIPTION
Add an "Examples" section to the documentation, to be able to look-up existing configuration for `jupyter-server-proxy`.

It also references the [`jupyter-server-proxy`](https://github.com/topics/jupyter-server-proxy) topic on GitHub as mentioned in https://discourse.jupyter.org/t/jupyter-server-proxy-gallery/1603

![image](https://user-images.githubusercontent.com/591645/92699809-565aa080-f34e-11ea-8643-65416df145fc.png)
