### PR TITLE
Adds Pluto notebook example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -8,6 +8,7 @@ If you are looking for examples on how to configure ``jupyter-server-proxy``, yo
 projects on GitHub, such as:
 
 - `jupyter-pgweb-proxy <https://github.com/illumidesk/jupyter-pgweb-proxy>`_: Run `pgweb <https://github.com/sosedoff/pgweb>`_ (cross-platform PostgreSQL client)
+- `jupyter-pluto-proxy <https://github.com/illumidesk/jupyter-pluto-proxy>`_: Run `Pluto.jl <https://github.com/fonsp/Pluto.jl>`_ (notebooks for Julia)
 - `jupyterserverproxy-openrefine <https://github.com/psychemedia/jupyterserverproxy-openrefine>`_: Run `OpenRefine <https://openrefine.org/>`_ (tool for working with messy data)
 - `mamba-navigator <https://github.com/mamba-org/mamba-navigator>`_: Run the Mamba Navigator (JupyterLab-based standalone application)
 


### PR DESCRIPTION
Adds `jupyter-proxy-server` example to the documentation for [Pluto.jl.](https://github.com/fonsp/Pluto.jl).