### PR TITLE
Use the recommended async with syntax to acquire and release an asyncio Lock

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -491,7 +491,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
         # FIXME: Make sure this times out properly?
         # Invariant here should be: when lock isn't being held, either 'proc' is in state &
         # running, or not.
-        with (await self.state['proc_lock']):
+        async with self.state['proc_lock']:
             if 'proc' not in self.state:
                 # FIXME: Prevent races here
                 # FIXME: Handle graceful exits of spawned processes here


### PR DESCRIPTION
I'm not sure exactly what is going on here, but we're seeing an error with this statement on Python 3.9:

```
      File "/[snip]/lib/python3.9/site-packages/jupyter_server_proxy/handlers.py", line 489, in ensure_process
        with (await self.state['proc_lock']):
    TypeError: object Lock can't be used in 'await' expression
```

See https://docs.python.org/3/library/asyncio-sync.html#asyncio.Lock

I think this also works in Python 3.5: https://docs.python.org/3/whatsnew/3.5.html#pep-492-coroutines-with-async-and-await-syntax