### PR TITLE
support to URL filename and URL parameters

### DIFF
--- a/jupyter_server_proxy/api.py
+++ b/jupyter_server_proxy/api.py
@@ -19,7 +19,8 @@ class ServersInfoHandler(IPythonHandler):
                 'name': sp.name,
                 'launcher_entry': {
                     'enabled': sp.launcher_entry.enabled,
-                    'title': sp.launcher_entry.title
+                    'title': sp.launcher_entry.title,
+                    'urlfile': sp.launcher_entry.urlfile,
                 },
                 'new_browser_tab' : sp.new_browser_tab
             }

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -99,7 +99,7 @@ def make_handlers(base_url, server_processes):
         ))
     return handlers
 
-LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title'])
+LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title', 'urlfile'])
 ServerProcess = namedtuple('ServerProcess', [
     'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'mappath', 'launcher_entry', 'new_browser_tab'])
 
@@ -116,7 +116,8 @@ def make_server_process(name, server_process_config):
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),
             icon_path=le.get('icon_path'),
-            title=le.get('title', name)
+            title=le.get('title', name),
+            urlfile=le.get('urlfile', ''),
         ),
         new_browser_tab=server_process_config.get('new_browser_tab', True)
     )
@@ -174,6 +175,10 @@ class ServerProxy(Configurable):
 
             title
               Title to be used for the launcher entry. Defaults to the name of the server if missing.
+
+            urlfile
+              URL file name and URL parameters to be added to the base URL of the launcher entry.
+              Default is none.
 
           new_browser_tab
             Set to True (default) to make the proxied server interface opened as a new browser tab. Set to False

--- a/jupyter_server_proxy/static/tree.js
+++ b/jupyter_server_proxy/static/tree.js
@@ -33,10 +33,14 @@ define(['jquery', 'base/js/namespace', 'base/js/utils'], function($, Jupyter, ut
                     .addClass('new-' + server_process.name);
 
                 /* create our list item's link */
+                var urlfile = '';
+                if (server_process.launcher_entry.urlfile) {
+                    urlfile =  server_process.launcher_entry.urlfile;
+                }
                 var $entry_link = $('<a>')
                     .attr('role', 'menuitem')
                     .attr('tabindex', '-1')
-                    .attr('href', base_url + server_process.name + '/')
+                    .attr('href', base_url + server_process.name + '/' + urlfile)
                     .attr('target', '_blank')
                     .text(server_process.launcher_entry.title);
 

--- a/jupyterlab-server-proxy/src/index.ts
+++ b/jupyterlab-server-proxy/src/index.ts
@@ -79,8 +79,11 @@ async function activate(app: JupyterFrontEnd, launcher: ILauncher, restorer: ILa
     if (!server_process.launcher_entry.enabled) {
       continue;
     }
-
-    const url = PageConfig.getBaseUrl() + server_process.name + '/';
+    var urlfile = '';
+    if (server_process.launcher_entry.urlfile) {
+       urlfile =  server_process.launcher_entry.urlfile;
+    }
+    const url = PageConfig.getBaseUrl() + server_process.name + '/' + urlfile;
     const title = server_process.launcher_entry.title;
     const newBrowserTab = server_process.new_browser_tab;
     const id = namespace + ':' + server_process.name;


### PR DESCRIPTION
Hello everyone,

[jupyter-xprahtml5-proxy](https://github.com/FZJ-JSC/jupyter-xprahtml5-proxy) adds support for [Xpra](https://xpra.org) (remote desktop) to Jupyter through the `jupyter-server-proxy` extension.

The [Xpra](https://xpra.org) HTML5 client can be configured through URL parameters. Expecially the username, password and encryption key is here of high importance to ensure that any user on a multiuser compute node can only connect to its own Xpra server. e.g. `http://localhost:10000/index.html?username=test&password=123456`

One might think, that this can be done through "mappath", but the Xpra-HTML5 client extracts the URL paramters from the URL through JavaScript in the browser. Therefor it requires that these URL parameters must not only be known on the server/python-side, but also on the client/JavaScript-side to be added to the URL of the launcher icon.

This is not supported yet by `jupyter-server-proxy` and added by this merge request.
The optional variable added to launcher_entry is called "urlfile".

How this can be used is shown in the development branch of jupyter-xprahtml5-proxy.
It now supports password+encryption, which was not possible before:
https://github.com/FZJ-JSC/jupyter-xprahtml5-proxy/blob/v0.3.0_devel/jupyter_xprahtml5_proxy/__init__.py

Let me know, what you think.
I think it is important and hope to see this in jupyter-server-proxy soon.

Best,
Jens Henrik