### PR TITLE
Rename the mamba-navigator example to gator in the documentation

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -10,7 +10,7 @@ projects on GitHub, such as:
 - `jupyter-pgweb-proxy <https://github.com/illumidesk/jupyter-pgweb-proxy>`_: Run `pgweb <https://github.com/sosedoff/pgweb>`_ (cross-platform PostgreSQL client)
 - `jupyter-pluto-proxy <https://github.com/illumidesk/jupyter-pluto-proxy>`_: Run `Pluto.jl <https://github.com/fonsp/Pluto.jl>`_ (notebooks for Julia)
 - `jupyterserverproxy-openrefine <https://github.com/psychemedia/jupyterserverproxy-openrefine>`_: Run `OpenRefine <https://openrefine.org/>`_ (tool for working with messy data)
-- `mamba-navigator <https://github.com/mamba-org/mamba-navigator>`_: Run the Mamba Navigator (JupyterLab-based standalone application)
+- `gator <https://github.com/mamba-org/gator>`_: Run the Mamba Navigator (JupyterLab-based standalone application)
 
 Projects can also add the ``jupyter-server-proxy`` topic to the GitHub repository to make it more discoverable:
 `https://github.com/topics/jupyter-server-proxy <https://github.com/topics/jupyter-server-proxy>`_


### PR DESCRIPTION
Since the project has now been moved to https://github.com/mamba-org/gator.