### PR TITLE
Bump to 1.6.0 (setup.py) and add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+## [1.6]
+
+### [1.6.0]
+
+This release adds support for JupyterLab 3.
+
+At this point, the Jupyterlab extension of version 2.1.2, needs to be installed
+alongside the Python package for JupyterLab launcher buttons to show up as the
+extension isn't yet bundled with the python package.
+
+#### Enhancements made
+
+* Add Jupyter Server extension data file (JupyterLab 3 support) [#235](https://github.com/jupyterhub/jupyter-server-proxy/pull/235) ([@jtpio](https://github.com/jtpio))
+* Update dependencies to include jupyterlab 3.x.x (JupyterLab 3 support) [#229](https://github.com/jupyterhub/jupyter-server-proxy/pull/229) ([@dipanjank](https://github.com/dipanjank))
+
+#### Documentation improvements
+
+* Replace server-process list with linkable headings [#236](https://github.com/jupyterhub/jupyter-server-proxy/pull/236) ([@manics](https://github.com/manics))
+* Rename the mamba-navigator example to gator in the documentation [#234](https://github.com/jupyterhub/jupyter-server-proxy/pull/234) ([@jtpio](https://github.com/jtpio))
+
+#### Contributors to this release
+
+[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AconsideRatio+updated%3A2021-01-05..2021-02-02&type=Issues) | [@dipanjank](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Adipanjank+updated%3A2021-01-05..2021-02-02&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ajtpio+updated%3A2021-01-05..2021-02-02&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Amanics+updated%3A2021-01-05..2021-02-02&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ayuvipanda+updated%3A2021-01-05..2021-02-02&type=Issues)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setuptools.setup(
     name="jupyter-server-proxy",
-    version='1.5.3',
+    version='1.6.0',
     url="https://github.com/jupyterhub/jupyter-server-proxy",
     author="Ryan Lovett & Yuvi Panda",
     author_email="rylo@berkeley.edu",


### PR DESCRIPTION
After upgrading to using ServerApp I stopped being able to use /rstudio.

> When I was using NotebookApp, visiting `/user/erik/rstudio/` would work fine. Now when I'm using ServerApp and JupyterHub 1.3.0, it seems that visiting `/user/erik/rstudio/` redirects to `/auth-sign-in?appUri=%2F` which bounce to `/hub/auth-sign-in?appUri=%2F` which jupyterhub doesn't recognize and responds with 404.

This question in gitter jupyter/jupyter_server led to @blink1073 helping out!

> hi @consideRatio! It looks like jupyter-server-proxy needs a new release with jupyterhub/jupyter-server-proxy#235.

So, here is a PR to release 1.6.0 of the Python package. The JupyterLab extension is already updated since last changed, version 2.1.2.

## Review
- [ ] Added a CHANGELOG.md file
  I generated it with [github-activity](https://github.com/executablebooks/github-activity)
- [ ] Bumped setup.py version to 1.6.0 from 1.5.3