### PR TITLE
tests: remove bad test, add new clarifying current behavior

### DIFF
--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -30,17 +30,6 @@ def test_server_proxy_minimal_proxy_path_encoding():
     s = r.read().decode('ascii')
     assert 'GET /{}&token='.format(special_path) in s
 
-def test_server_proxy_minimal_proxy_path_encoding_complement():
-    """Test that we don't encode ?# as a complement to the other test."""
-    test_url = '/python-http/?token={}#test'.format(TOKEN)
-    h = HTTPConnection('localhost', PORT, 10)
-    r = request_get(PORT, test_url, TOKEN)
-    h.request('GET', test_url)
-    return h.getresponse()
-    assert r.code == 200
-    s = r.read().decode('ascii')
-    assert 'GET /{}?token='.format(test_url) in s
-
 
 def test_server_proxy_non_absolute():
     r = request_get(PORT, '/python-http/abc', TOKEN)

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -31,6 +31,59 @@ def test_server_proxy_minimal_proxy_path_encoding():
     assert 'GET /{}&token='.format(special_path) in s
 
 
+def test_server_proxy_hash_sign_encoding():
+    """
+    FIXME: This is a test to establish the current behavior, but if it should be
+           like this is a separate question not yet addressed.
+
+           Related: https://github.com/jupyterhub/jupyter-server-proxy/issues/109
+    """
+    h = HTTPConnection("localhost", PORT, 10)
+
+    # Case 0: a reference case
+    path = "?token={}".format(TOKEN)
+    h.request('GET', '/python-http/' + path)
+    r = h.getresponse()
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert 'GET /{} '.format(path) in s
+
+    # Case 1: #bla?token=secret -> everything following # ignored -> redirect because no token
+    path = "#bla?token={}".format(TOKEN)
+    h.request('GET', '/python-http/' + path)
+    r = h.getresponse()
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert 'GET / ' in s
+
+    # Case 2: %23bla?token=secret -> %23 is # -> everything following # ignored -> redirect because no token
+    path = "%23?token={}".format(TOKEN)
+    h.request('GET', '/python-http/' + path)
+    r = h.getresponse()
+    assert r.code == 200
+    s = r.read().decode('ascii')
+    assert 'GET / ' in s
+
+    # Case 3: ?token=secret#test -> invalid token -> jupyter notebook server errors: NoneType can't be used in 'await' expression
+    #
+    #   [E 11:37:49.991 NotebookApp] Uncaught exception GET /python-http/?token=secrettest (127.0.0.1)
+    #   HTTPServerRequest(protocol='http', host='localhost:8888', method='GET', uri='/python-http/?token=secrettest', version='HTTP/1.1', remote_ip='127.0.0.1')
+    #   Traceback (most recent call last):
+    #   File "/home/erik/py/lib/python3.7/site-packages/tornado/web.py", line 1704, in _execute
+    #       result = await result
+    #   File "/home/erik/py/lib/python3.7/site-packages/jupyter_server_proxy/websocket.py", line 97, in get
+    #       return await self.http_get(*args, **kwargs)
+    #   File "/home/erik/py/lib/python3.7/site-packages/jupyter_server_proxy/handlers.py", line 539, in http_get
+    #       return await self.proxy(self.port, path)
+    #   TypeError: object NoneType can't be used in 'await' expression
+    path = "?token={}#test".format(TOKEN)
+    h.request('GET', '/python-http/' + path)
+    r = h.getresponse()
+    assert r.code == 302
+    s = r.read().decode('ascii')
+    assert s == ''
+
+
 def test_server_proxy_non_absolute():
     r = request_get(PORT, '/python-http/abc', TOKEN)
     assert r.code == 200

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -23,14 +23,12 @@ def request_get(port, path, token, host='localhost'):
 def test_server_proxy_minimal_proxy_path_encoding():
     """Test that we don't encode anything more than we must to have a valid web
     request."""
-    special_path = quote("Hello world 123 åäö 🎉你好世界±¥ :/[]@!$&'()*+,;=-._~", safe=":/?#[]@!$&'()*+,;=-._~")
-    # NOTE: we left out ?# as they would interact badly with our requests_get
-    # function's ability to pass the token query parameter.
+    special_path = quote("Hello world 123 åäö 🎉你好世界±¥ :/[]@!$&'()*+,;=-._~?key1=value1", safe=":/?#[]@!$&'()*+,;=-._~")
     test_url = '/python-http/' + special_path
     r = request_get(PORT, test_url, TOKEN)
     assert r.code == 200
     s = r.read().decode('ascii')
-    assert 'GET /{}?token='.format(special_path) in s
+    assert 'GET /{}&token='.format(special_path) in s
 
 def test_server_proxy_minimal_proxy_path_encoding_complement():
     """Test that we don't encode ?# as a complement to the other test."""


### PR DESCRIPTION
We had a false positive test because it was `return`-ing before its assertions which was the actual test. With this updated test I make the current behavior clear, but I also document in the docstring a FIXME that this is only the current behavior verified with a test, not that it is the desired behavior which isn't known to me.

Closes #239

## Off topic
This is no fix for #109, but it highlights that you can get that kind of error when ?token=wrongtoken is passed to the Jupyter Notebook server, which probably is an issue with notebook server. Right?