### PR TITLE
docs: mv local dev setup to CONTRIBUTING.md and document tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,8 @@ jobs:
           python-version: "${{ matrix.python }}"
 
       - name: Install Python dependencies
+        # NOTE: See CONTRIBUTING.md for a local development setup that differs
+        #       slightly from this.
         run: |
           pip install --upgrade pip
           pip install .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,67 @@
 # Contributing
 
 Welcome! As a [Jupyter](https://jupyter.org) project, we follow the [Jupyter contributor guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
+
+To setup a local development environment and ru tests, see the small section in
+the README.md file.
+
+## Local development setup
+
+### Python package
+
+```bash
+pip install -e .
+
+# explicit install needed with editable mode (-e) jupyter
+jupyter serverextension enable --sys-prefix jupyter_server_proxy
+```
+
+Before running tests, you need a [notebook
+server](https://github.com/jupyter/notebook) that we can test against.
+
+```
+JUPYTER_TOKEN=secret jupyter-notebook --config=./tests/resources/jupyter_server_config.py
+```
+
+Run the tests:
+
+```
+pytest --verbose
+```
+
+### JupyterLab extension
+
+The `jlpm` command is JupyterLab's pinned version of `yarn` that is
+installed with JupyterLab. You may use `yarn` or `npm` instead of `jlpm`
+below.
+
+```bash
+cd jupyterlab-server-proxy
+
+# Install dependencies
+jlpm
+
+# Build Typescript source
+jlpm build
+
+# Link your development version of the extension with JupyterLab
+jupyter labextension link .
+
+# Rebuild Typescript source after making changes
+jlpm build
+
+# Rebuild JupyterLab after making any changes
+jupyter lab build
+```
+
+You can watch the source directory and run JupyterLab in watch mode to
+watch for changes in the extension's source and automatically rebuild
+the extension and application.
+
+```bash
+# Watch the source directory in another terminal tab
+jlpm watch
+
+# Run jupyterlab in watch mode in one terminal tab
+jupyter lab --watch
+```

--- a/README.md
+++ b/README.md
@@ -58,50 +58,6 @@ requires the python package to be installed.
 jupyter labextension install @jupyterlab/server-proxy
 ```
 
-## Contributing
+## Local development
 
-### Python package
-
-```
-pip install -e .
-
-# explicit install needed with editable mode (-e) jupyter
-jupyter serverextension enable --sys-prefix jupyter_server_proxy
-```
-
-### JupyterLab extension
-
-The `jlpm` command is JupyterLab's pinned version of `yarn` that is
-installed with JupyterLab. You may use `yarn` or `npm` instead of `jlpm`
-below.
-
-```
-cd jupyterlab-server-proxy
-
-# Install dependencies
-jlpm
-
-# Build Typescript source
-jlpm build
-
-# Link your development version of the extension with JupyterLab
-jupyter labextension link .
-
-# Rebuild Typescript source after making changes
-jlpm build
-
-# Rebuild JupyterLab after making any changes
-jupyter lab build
-```
-
-You can watch the source directory and run JupyterLab in watch mode to
-watch for changes in the extension's source and automatically rebuild
-the extension and application.
-
-```
-# Watch the source directory in another terminal tab
-jlpm watch
-
-# Run jupyterlab in watch mode in one terminal tab
-jupyter lab --watch
-```
+See [CONTRIBUTING.md].


### PR DESCRIPTION
I struggled a while with `pip install -e .` not functioning because I copied CI instructions from test.yaml because I didn't see any setup instructions in the CONTRIBUTING.md that we had. I found later that the README.md had instructions though.

So, I made a note in the README.md and test.yaml to look in CONTRIBUTING.md where I described also described how to run tests.