### PR TITLE
Add configurable choice of a JupyterLab launcher category to present registered proxies (Notebook, Console, Other)

### DIFF
--- a/jupyterlab-server-proxy/package.json
+++ b/jupyterlab-server-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/server-proxy",
-  "version": "2.1.2",
+  "version": "2.1.2-dev",
   "description": "Launcher icons for proxied applications",
   "keywords": [
     "jupyter",

--- a/jupyterlab-server-proxy/package.json
+++ b/jupyterlab-server-proxy/package.json
@@ -15,6 +15,7 @@
   "author": "Yuvi Panda",
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "schema/**/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
   "main": "lib/index.js",
@@ -32,13 +33,15 @@
   "dependencies": {
     "@jupyterlab/application": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "@jupyterlab/apputils": "^1.0.0 || ^2.0.0 || ^3.0.0",
-    "@jupyterlab/launcher": "^1.0.0 || ^2.0.0 || ^3.0.0"
+    "@jupyterlab/launcher": "^1.0.0 || ^2.0.0 || ^3.0.0",
+    "@jupyterlab/settingregistry": "^1.0.0 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",
     "typescript": "~3.7.0"
   },
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "schemaDir": "schema"
   }
 }

--- a/jupyterlab-server-proxy/schema/plugin.json
+++ b/jupyterlab-server-proxy/schema/plugin.json
@@ -1,0 +1,13 @@
+{
+  "title": "Server Proxy",
+  "description": "Settings for the Server Proxy extension",
+  "type": "object",
+  "properties": {
+    "category": {
+      "type": "string",
+      "title": "Category",
+      "description": "Category of proxy launchers",
+      "default": "Notebook"
+    }
+  }
+}

--- a/jupyterlab-server-proxy/src/index.ts
+++ b/jupyterlab-server-proxy/src/index.ts
@@ -23,7 +23,7 @@ function newServerProxyWidget(id: string, url: string, text: string): MainAreaWi
   return widget;
 }
 
-async function activate(app: JupyterFrontEnd, launcher: ILauncher, restorer: ILayoutRestorer, settingRegistry: ISettingRegistry) : Promise<void> {
+async function activate(app: JupyterFrontEnd, launcher: ILauncher, restorer: ILayoutRestorer, settingRegistry: ISettingRegistry): Promise<void> {
   const response = await fetch(PageConfig.getBaseUrl() + 'server-proxy/servers-info');
   if (!response.ok) {
     console.log('Could not fetch metadata about registered servers. Make sure jupyter-server-proxy is installed.');
@@ -41,12 +41,12 @@ async function activate(app: JupyterFrontEnd, launcher: ILauncher, restorer: ILa
   var category = 'Notebook';
 
   if (settingRegistry) {
-      const setting = await settingRegistry.load(extension.id);
-      const updateSettings = (): void => {
-        category = setting.get('category').composite as string;
-      };
-      updateSettings();
-      setting.changed.connect(updateSettings);
+    const setting = await settingRegistry.load(extension.id);
+    const updateSettings = (): void => {
+      category = setting.get('category').composite as string;
+    };
+    updateSettings();
+    setting.changed.connect(updateSettings);
   }
 
   if (restorer) {
@@ -74,7 +74,7 @@ async function activate(app: JupyterFrontEnd, launcher: ILauncher, restorer: ILa
         return;
       }
       let widget = tracker.find((widget) => { return widget.content.id == id; });
-      if(!widget){
+      if (!widget) {
         widget = newServerProxyWidget(id, url, title);
       }
       if (!tracker.has(widget)) {
@@ -98,11 +98,11 @@ async function activate(app: JupyterFrontEnd, launcher: ILauncher, restorer: ILa
     const title = server_process.launcher_entry.title;
     const newBrowserTab = server_process.new_browser_tab;
     const id = namespace + ':' + server_process.name;
-    const launcher_item : ILauncher.IItemOptions = {
+    const launcher_item: ILauncher.IItemOptions = {
       command: command,
       args: {
         url: url,
-        title: title + (newBrowserTab ? ' [↗]': ''),
+        title: title + (newBrowserTab ? ' [↗]' : ''),
         newBrowserTab: newBrowserTab,
         id: id
       },
@@ -110,7 +110,7 @@ async function activate(app: JupyterFrontEnd, launcher: ILauncher, restorer: ILa
     };
 
     if (server_process.launcher_entry.icon_url) {
-      launcher_item.kernelIconUrl =  server_process.launcher_entry.icon_url;
+      launcher_item.kernelIconUrl = server_process.launcher_entry.icon_url;
     }
     launcher.add(launcher_item);
   }


### PR DESCRIPTION
As preparation work for #145 this pull request adds the capability to configure under which launcher category the proxy applications will appear. 

It needs a bit of check from people who have more experience with extensions.
Screenshots follow.

<img width="360" alt="Screenshot 2021-02-08 at 20 54 39" src="https://user-images.githubusercontent.com/3780274/107280628-7d79e300-6a50-11eb-9d1c-fff540479107.png">

<img width="796" alt="Screenshot 2021-02-08 at 20 55 23" src="https://user-images.githubusercontent.com/3780274/107280576-6b984000-6a50-11eb-87dd-7c5cdc4d7dd4.png">

<img width="533" alt="Screenshot 2021-02-08 at 20 55 53" src="https://user-images.githubusercontent.com/3780274/107280653-85398780-6a50-11eb-8ec6-6051c2ca2efb.png">

