### PR TITLE
Add publish PyPI and NPM workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,81 @@
+# Publish PyPI and NPM artifacts
+name: Publish
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Build dist
+        run: |
+          pip install jupyter_packaging wheel jupyterlab~=3.0
+          python setup.py sdist bdist_wheel
+
+      - name: Javascript package
+        run: |
+          mkdir jsdist
+          cd jupyterlab-server-proxy
+          jlpm pack --filename ../jsdist/jupyterlab-server-proxy-jlpmpack.tgz
+
+      - name: Upload Python artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+          if-no-files-found: error
+
+      - name: Upload Javascript artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: jsdist
+          path: jsdist
+          if-no-files-found: error
+
+  # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+  publish-pypi:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v2
+      - name: Download artifacts from build
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@v1.3.0
+        with:
+          password: ${{ secrets.PYPI_PASSWORD }}
+
+  # https://docs.github.com/en/actions/language-and-framework-guides/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
+  publish-npm:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+          registry-url: https://registry.npmjs.org
+      - name: Download artifacts from build
+        uses: actions/download-artifact@v2
+        with:
+          name: jsdist
+          path: jsdist
+      - run: npm publish --dry-run ./jsdist/jupyterlab-server-proxy-jlpmpack.tgz
+      - run: npm publish ./jsdist/jupyterlab-server-proxy-jlpmpack.tgz
+        if: startsWith(github.ref, 'refs/tags')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,7 @@ name: Publish
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
 
@@ -64,7 +65,7 @@ jobs:
       - build
     runs-on: ubuntu-latest
     steps:
-      # Setup .npmrc file to publish to npm
+      # actions/setup-node creates an .npmrc file that references NODE_AUTH_TOKEN
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x


### PR DESCRIPTION
https://github.com/jupyterhub/jupyter-server-proxy/pull/245 incorporates the JupyterLab extension into the Python package and uses a single version number for both, which means when it's merged we can publish everything automatically.

This adds a new `Publish` workflow where the build and publish steps for PyPI and NPM are copied from
https://github.com/manics/jupyter-offlinenotebook/blob/340e0e7ac80f01d276c2e68d03144fe1078d5c86/.github/workflows/build.yml#L57-L72
https://github.com/manics/jupyter-offlinenotebook/blob/340e0e7ac80f01d276c2e68d03144fe1078d5c86/.github/workflows/build.yml#L118-L161

This requires two repository secrets:
- [x] `secrets.PYPI_PASSWORD`
- [x] `secrets.NPM_TOKEN`