### PR TITLE
docs: updates to changelog, readme, release for the 3.0.0 release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
         # We run this job multiple times with different parameterization
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
-        jupyterlab_version: [1, 2, 3]
+        jupyterlab_version: [2, 3]
         python: [3.6, 3.7, 3.8, 3.9]
         jupyter_app: [notebook]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,34 @@
+## [3.0]
+
+### [3.0.0] - UNRELEASED, TODO UPDATE DATE
+
+This release drops support for Python 3.5 and now packages the JupyterLab
+extension with the Python package. The JupyterLab extension is still available
+on NPM for use with JupyterLab 2.
+
+The Python package version jumps from 1.6.0 to 3.0.0, and the NPM package
+version jumps from 2.1.2 to 3.0.0.
+
+#### Enhancements made
+
+* Package jupyter lab extension [#245](https://github.com/jupyterhub/jupyter-server-proxy/pull/245) ([@janjagusch](https://github.com/janjagusch))
+
+#### Documentation improvements
+
+* Bump to 1.6.0 (setup.py) and add CHANGELOG.md [#238](https://github.com/jupyterhub/jupyter-server-proxy/pull/238) ([@consideRatio](https://github.com/consideRatio))
+
+#### Continuous integration
+
+* Add publish PyPI and NPM workflow [#247](https://github.com/jupyterhub/jupyter-server-proxy/pull/247) ([@manics](https://github.com/manics))
+
+#### Contributors to this release
+
+[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AconsideRatio+updated%3A2021-02-08..2021-02-18&type=Issues) | [@janjagusch](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ajanjagusch+updated%3A2021-02-08..2021-02-18&type=Issues) | [@JanJaguschQC](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AJanJaguschQC+updated%3A2021-02-08..2021-02-18&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Amanics+updated%3A2021-02-08..2021-02-18&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ayuvipanda+updated%3A2021-02-08..2021-02-18&type=Issues)
+
+
 ## [1.6]
 
-### [1.6.0]
+### [1.6.0] - 2021-02-10
 
 This release adds support for JupyterLab 3.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [3.0]
 
-### [3.0.0] - UNRELEASED, TODO UPDATE DATE
+### [3.0.0] - 2020-02-25
 
 This release drops support for Python 3.5 and now packages the JupyterLab
 extension with the Python package for use with JupyterLab 3. The JupyterLab
@@ -20,7 +20,9 @@ version jumps from 2.1.2 to 3.0.0.
 
 #### Continuous integration
 
+* Fix build.yaml workflow [#249](https://github.com/jupyterhub/jupyter-server-proxy/pull/249) ([@manics](https://github.com/manics))
 * Add publish PyPI and NPM workflow [#247](https://github.com/jupyterhub/jupyter-server-proxy/pull/247) ([@manics](https://github.com/manics))
+* tests: remove bad test, add new clarifying current behavior [#240](https://github.com/jupyterhub/jupyter-server-proxy/pull/240) ([@consideRatio](https://github.com/consideRatio))
 
 #### Contributors to this release
 
@@ -49,4 +51,4 @@ extension isn't yet bundled with the python package.
 
 #### Contributors to this release
 
-[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AconsideRatio+updated%3A2021-01-05..2021-02-02&type=Issues) | [@dipanjank](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Adipanjank+updated%3A2021-01-05..2021-02-02&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ajtpio+updated%3A2021-01-05..2021-02-02&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Amanics+updated%3A2021-01-05..2021-02-02&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ayuvipanda+updated%3A2021-01-05..2021-02-02&type=Issues)
+[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AconsideRatio+updated%3A2021-02-08..2021-02-25&type=Issues) | [@janjagusch](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ajanjagusch+updated%3A2021-02-08..2021-02-25&type=Issues) | [@JanJaguschQC](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AJanJaguschQC+updated%3A2021-02-08..2021-02-25&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ajtpio+updated%3A2021-02-08..2021-02-25&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Amanics+updated%3A2021-02-08..2021-02-25&type=Issues) | [@ryanlovett](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Aryanlovett+updated%3A2021-02-08..2021-02-25&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ayuvipanda+updated%3A2021-02-08..2021-02-25&type=Issues)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ### [3.0.0] - UNRELEASED, TODO UPDATE DATE
 
 This release drops support for Python 3.5 and now packages the JupyterLab
-extension with the Python package. The JupyterLab extension is still available
-on NPM for use with JupyterLab 2.
+extension with the Python package for use with JupyterLab 3. The JupyterLab
+extension is still available on NPM for use with JupyterLab 2 but support for
+JupyterLab 1 is dropped.
 
 The Python package version jumps from 1.6.0 to 3.0.0, and the NPM package
 version jumps from 2.1.2 to 3.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [3.0]
 
-### [3.0.0] - 2020-02-25
+### [3.0.0] - 2020-03-15
 
 This release drops support for Python 3.5 and now packages the JupyterLab
 extension with the Python package for use with JupyterLab 3. The JupyterLab
@@ -14,20 +14,23 @@ version jumps from 2.1.2 to 3.0.0.
 
 * Package jupyter lab extension [#245](https://github.com/jupyterhub/jupyter-server-proxy/pull/245) ([@janjagusch](https://github.com/janjagusch))
 
-#### Documentation improvements
+#### Maintenance and upkeep improvements
 
-* Bump to 1.6.0 (setup.py) and add CHANGELOG.md [#238](https://github.com/jupyterhub/jupyter-server-proxy/pull/238) ([@consideRatio](https://github.com/consideRatio))
+* Breaking: Replace host_whitelist with host_allowlist [#256](https://github.com/jupyterhub/jupyter-server-proxy/pull/256) ([@manics](https://github.com/manics))
+* Switch from notebook to jupyter-server [#254](https://github.com/jupyterhub/jupyter-server-proxy/pull/254) ([@manics](https://github.com/manics))
 
 #### Continuous integration
 
+* Move build.yaml into test.yaml [#255](https://github.com/jupyterhub/jupyter-server-proxy/pull/255) ([@manics](https://github.com/manics))
 * Fix build.yaml workflow [#249](https://github.com/jupyterhub/jupyter-server-proxy/pull/249) ([@manics](https://github.com/manics))
 * Add publish PyPI and NPM workflow [#247](https://github.com/jupyterhub/jupyter-server-proxy/pull/247) ([@manics](https://github.com/manics))
 * tests: remove bad test, add new clarifying current behavior [#240](https://github.com/jupyterhub/jupyter-server-proxy/pull/240) ([@consideRatio](https://github.com/consideRatio))
 
 #### Contributors to this release
 
-[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AconsideRatio+updated%3A2021-02-08..2021-02-18&type=Issues) | [@janjagusch](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ajanjagusch+updated%3A2021-02-08..2021-02-18&type=Issues) | [@JanJaguschQC](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AJanJaguschQC+updated%3A2021-02-08..2021-02-18&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Amanics+updated%3A2021-02-08..2021-02-18&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ayuvipanda+updated%3A2021-02-08..2021-02-18&type=Issues)
+([GitHub contributors page for this release](https://github.com/jupyterhub/jupyter-server-proxy/graphs/contributors?from=2021-02-08&to=2021-03-15&type=c))
 
+[@AlJohri](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AAlJohri+updated%3A2021-02-08..2021-03-15&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AconsideRatio+updated%3A2021-02-08..2021-03-15&type=Issues) | [@ian-r-rose](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Aian-r-rose+updated%3A2021-02-08..2021-03-15&type=Issues) | [@janjagusch](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ajanjagusch+updated%3A2021-02-08..2021-03-15&type=Issues) | [@JanJaguschQC](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3AJanJaguschQC+updated%3A2021-02-08..2021-03-15&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ajtpio+updated%3A2021-02-08..2021-03-15&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Amanics+updated%3A2021-02-08..2021-03-15&type=Issues) | [@maresb](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Amaresb+updated%3A2021-02-08..2021-03-15&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Aminrk+updated%3A2021-02-08..2021-03-15&type=Issues) | [@ryanlovett](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Aryanlovett+updated%3A2021-02-08..2021-03-15&type=Issues) | [@todo](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Atodo+updated%3A2021-02-08..2021-03-15&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fjupyter-server-proxy+involves%3Ayuvipanda+updated%3A2021-02-08..2021-03-15&type=Issues)
 
 ## [1.6]
 
@@ -46,6 +49,7 @@ extension isn't yet bundled with the python package.
 
 #### Documentation improvements
 
+* Bump to 1.6.0 (setup.py) and add CHANGELOG.md [#238](https://github.com/jupyterhub/jupyter-server-proxy/pull/238) ([@consideRatio](https://github.com/consideRatio))
 * Replace server-process list with linkable headings [#236](https://github.com/jupyterhub/jupyter-server-proxy/pull/236) ([@manics](https://github.com/manics))
 * Rename the mamba-navigator example to gator in the documentation [#234](https://github.com/jupyterhub/jupyter-server-proxy/pull/234) ([@jtpio](https://github.com/jtpio))
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Note that as the JupyterLab extension only is a graphical interface to
 launch registered applications in the python package, the extension
 requires the python package to be installed.
 
+As of version 3.0.0 the Python package ships with a JupyterLab 3 compatible
+extension, making this step only needed for JupyterLab 2.
+
 ```
 jupyter labextension install @jupyterlab/server-proxy
 ```

--- a/docs/contributing/release.rst
+++ b/docs/contributing/release.rst
@@ -11,37 +11,33 @@ Packages in this repository
 
 This repo has more than one package.
 
-#. The primary ``jupyter-server-proxy`` python package. This contains the actual proxying
-   code, and the classic notebook extension. This is published on `PyPI <https://pypi.org>`_.
+#. The primary ``jupyter-server-proxy`` python package. This contains the actual
+   proxying code, and the classic notebook extension. This is published on `PyPI
+   <https://pypi.org/project/jupyter-server-proxy>`_.
 
-#. The JupyterLab plugin, ``jupyterlab-server-proxy``. This provides the launcher icons in
-   JupyterLab.
+#. The JupyterLab plugin, ``jupyterlab-server-proxy``. This provides the
+   launcher icons in JupyterLab. This is packaged into the Python package but
+   also published to `NPM
+   <https://www.npmjs.com/package/@jupyterlab/server-proxy>`_ for JupyterLab 2
+   compatibility.
 
-#. Various python packages in ``contrib/``. These are convenience packages that help set up
-   a particular application for use - such as RStudio or Theia.
+#. Various python packages in ``contrib/``. These are convenience packages that
+   help set up a particular application for use - such as Theia.
 
-We try to keep the version numbers of all these packages in sync, even when there are no
-changes. This keeps reasoning about versions simple.
+As of version 3.0.0, we keep the version numbers of the main Python package and
+the JupyterLab plugin in sync, but have no procedure for the Theia package yet.
 
 Gaining Access Privileges
 =========================
 
-Before making a release, you need access privileges for the following.
-
-#. Write access to the `GitHub repo <https://github.com/jupyterhub/jupyter-server-proxy>`_.
-
-#. Publish access to the various python packages on PyPI.
-
-#. Publish access to the JupyterLab plugin on `NPM <https://www.npmjs.com/>`_.
+To make a release, you only need privileges to create a tag as there is
+automation to publish in GitHub workflows when a tag is pushed.
 
 Release checklist
 =================
 
-#. Update the package version number in ``setup.py``.
-
-#. Update the JupyterLab plugin's version to match, in ``jupyterlab-server-proxy/package.json``.
-   We keep these two versions in sync to avoid figuring out a matrix of 'which version of
-   the python package is compatible with which version of the JupyterLab plugin?'
+#. Update the package version number in
+   ``jupyterlab-server-proxy/package.json``, it will be read by ``setup.py``.
 
 #. Commit these changes and make a pull request with it. 
 
@@ -56,22 +52,3 @@ Release checklist
    .. code::
      
       git push git@github.com:jupyterhub/jupyter-server-proxy --tags
-
-#. Publish the package on PyPI
-
-   .. code::
-
-      pip install twine
-      rm -rf dist/*
-      python3 setup.py sdist bdist_wheel
-      twine upload dist/*
-
-#. Publish the JupyterLab plugin on npm
-
-   .. code::
-
-      cd jupyterlab-server-proxy
-      npm install
-      npm login
-      npm publish
-

--- a/docs/contributing/release.rst
+++ b/docs/contributing/release.rst
@@ -26,6 +26,8 @@ This repo has more than one package.
 
 As of version 3.0.0, we keep the version numbers of the main Python package and
 the JupyterLab plugin in sync, but have no procedure for the Theia package yet.
+NPM package versioning is stricter than Python package versioning.
+For example if you want to release a release candidate the version should be in the form `3.0.0-rc.1`, python will automatically treat this as `3.0.0rc1`.
 
 Gaining Access Privileges
 =========================

--- a/jupyterlab-server-proxy/package.json
+++ b/jupyterlab-server-proxy/package.json
@@ -45,9 +45,9 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@jupyterlab/application": "^1.0.0 || ^2.0.0 || ^3.0.0",
-    "@jupyterlab/apputils": "^1.0.0 || ^2.0.0 || ^3.0.0",
-    "@jupyterlab/launcher": "^1.0.0 || ^2.0.0 || ^3.0.0"
+    "@jupyterlab/application": "^2.0.0 || ^3.0.0",
+    "@jupyterlab/apputils": "^2.0.0 || ^3.0.0",
+    "@jupyterlab/launcher": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.0.2",


### PR DESCRIPTION
- [x] Updated README.md following #245 to reflect that the extension must now only be installed as a NPM package with JupyterLab 2 (Py35 and JupyterLab 1 support dropped)
- [x] Updated CHANGELOG.md with changes since 1.6.0
- [x] Updated release.rst to reflect the practice to now always release Python / NPM package with the same version and how to do it using the GitHub workflows introduced with #247.
- [x] Drop test cases associated with JupyterLab 1 that didn't properly test it and drop support for JupyterLab 1 explicitly.