### PR TITLE
Switch from notebook to jupyter-server

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,8 @@ jobs:
         # We run this job multiple times with different parameterization
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
-        jupyterlab_version: [1, 2, 3]
+        # 0 is a placeholder that indicates jupyter-server should be tested on its own
+        jupyterlab_version: [0, 1, 2, 3]
         python: [3.6, 3.7, 3.8, 3.9]
 
     steps:
@@ -59,7 +60,12 @@ jobs:
           pip freeze
       - name: Run tests
         run: |
-          JUPYTER_TOKEN=secret jupyter-notebook --config=./tests/resources/jupyter_server_config.py &
+          if [ ${{ matrix.jupyterlab_version }} -gt 0 ]; then
+              APP=notebook
+          else
+              APP=server
+          fi
+          JUPYTER_TOKEN=secret jupyter-$APP --config=./tests/resources/jupyter_server_config.py &
           sleep 5
           pytest --verbose --color=yes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,9 +35,15 @@ jobs:
         # We run this job multiple times with different parameterization
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
-        # 0 is a placeholder that indicates jupyter-server should be tested on its own
-        jupyterlab_version: [0, 1, 2, 3]
+        jupyterlab_version: [1, 2, 3]
         python: [3.6, 3.7, 3.8, 3.9]
+        jupyter_app: [notebook]
+        include:
+          # includes a new variable of npm with a value of 2
+          # for the matrix leg matching the os and version
+          - jupyterlab_version: 3
+            python: 3.9
+            jupyter_app: server
 
     steps:
       - uses: actions/checkout@v2
@@ -60,12 +66,7 @@ jobs:
           pip freeze
       - name: Run tests
         run: |
-          if [ ${{ matrix.jupyterlab_version }} -gt 0 ]; then
-              APP=notebook
-          else
-              APP=server
-          fi
-          JUPYTER_TOKEN=secret jupyter-$APP --config=./tests/resources/jupyter_server_config.py &
+          JUPYTER_TOKEN=secret jupyter-${{ matrix.jupyter_app }} --config=./tests/resources/jupyter_server_config.py &
           sleep 5
           pytest --verbose --color=yes
 

--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -1,6 +1,6 @@
 from .handlers import setup_handlers, SuperviseAndProxyHandler
 from .config import ServerProxy, make_handlers, get_entrypoint_server_processes, make_server_process
-from notebook.utils import url_path_join as ujoin
+from jupyter_server.utils import url_path_join as ujoin
 from .api import ServersInfoHandler, IconHandler
 
 # Jupyter Extension points

--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -4,7 +4,7 @@ from jupyter_server.utils import url_path_join as ujoin
 from .api import ServersInfoHandler, IconHandler
 
 # Jupyter Extension points
-def _jupyter_server_extension_paths():
+def _jupyter_server_extension_points():
     return [{
         'module': 'jupyter_server_proxy',
     }]
@@ -18,7 +18,7 @@ def _jupyter_nbextension_paths():
     }]
 
 
-def load_jupyter_server_extension(nbapp):
+def _load_jupyter_server_extension(nbapp):
     # Set up handlers picked up via config
     base_url = nbapp.web_app.settings['base_url']
     serverproxy = ServerProxy(parent=nbapp)
@@ -41,3 +41,7 @@ def load_jupyter_server_extension(nbapp):
         (ujoin(base_url, 'server-proxy/servers-info'), ServersInfoHandler, {'server_processes': server_processes}),
         (ujoin(base_url, 'server-proxy/icon/(.*)'), IconHandler, {'icons': icons})
     ])
+
+
+# For backward compatibility
+load_jupyter_server_extension = _load_jupyter_server_extension

--- a/jupyter_server_proxy/api.py
+++ b/jupyter_server_proxy/api.py
@@ -1,10 +1,10 @@
 from tornado import web
 import mimetypes
-from notebook.base.handlers import IPythonHandler
-from notebook.utils import url_path_join as ujoin
+from jupyter_server.base.handlers import JupyterHandler
+from jupyter_server.utils import url_path_join as ujoin
 from collections import namedtuple
 
-class ServersInfoHandler(IPythonHandler):
+class ServersInfoHandler(JupyterHandler):
     def initialize(self, server_processes):
         self.server_processes = server_processes
 
@@ -33,7 +33,7 @@ class ServersInfoHandler(IPythonHandler):
 
 
 # FIXME: Should be a StaticFileHandler subclass
-class IconHandler(IPythonHandler):
+class IconHandler(JupyterHandler):
     """
     Serve launcher icons
     """

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -1,7 +1,7 @@
 """
 Traitlets based configuration for jupyter_server_proxy
 """
-from notebook.utils import url_path_join as ujoin
+from jupyter_server.utils import url_path_join as ujoin
 from traitlets import Dict, List, Union, default
 from traitlets.config import Configurable
 from .handlers import SuperviseAndProxyHandler, AddSlashHandler

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -13,7 +13,7 @@ from asyncio import Lock
 
 from tornado import gen, web, httpclient, httputil, process, websocket, ioloop, version_info
 
-from jupyter_server.utils import url_path_join
+from jupyter_server.utils import ensure_async, url_path_join
 from jupyter_server.base.handlers import JupyterHandler, utcnow
 
 from .utils import call_with_asked_args
@@ -532,11 +532,11 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
 
         await self.ensure_process()
 
-        return await super().proxy(self.port, path)
+        return await ensure_async(super().proxy(self.port, path))
 
 
     async def http_get(self, path):
-        return await self.proxy(self.port, path)
+        return await ensure_async(self.proxy(self.port, path))
 
     async def open(self, path):
         await self.ensure_process()

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -13,15 +13,15 @@ from asyncio import Lock
 
 from tornado import gen, web, httpclient, httputil, process, websocket, ioloop, version_info
 
-from notebook.utils import url_path_join
-from notebook.base.handlers import IPythonHandler, utcnow
+from jupyter_server.utils import url_path_join
+from jupyter_server.base.handlers import JupyterHandler, utcnow
 
 from .utils import call_with_asked_args
 from .websocket import WebSocketHandlerMixin, pingable_ws_connect
 from simpervisor import SupervisedProcess
 
 
-class AddSlashHandler(IPythonHandler):
+class AddSlashHandler(JupyterHandler):
     """Add trailing slash to URLs that need them."""
     @web.authenticated
     def get(self, *args):
@@ -29,7 +29,7 @@ class AddSlashHandler(IPythonHandler):
         dest = src._replace(path=src.path + '/')
         self.redirect(urlunparse(dest))
 
-class ProxyHandler(WebSocketHandlerMixin, IPythonHandler):
+class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
     """
     A tornado request handler that proxies HTTP and websockets from
     a given host/port combination. This class is not meant to be

--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -11,13 +11,13 @@ from urllib.parse import urlunparse, urlparse
 
 from tornado import gen, web, httpclient, httputil, process, websocket, ioloop, version_info
 
-from notebook.utils import url_path_join
-from notebook.base.handlers import IPythonHandler, utcnow
+from jupyter_server.utils import url_path_join
+from jupyter_server.base.handlers import JupyterHandler, utcnow
 
 try:
     # Tornado 6.0 deprecated its `maybe_future` function so `notebook` made their own.
     # See: https://github.com/jupyter/notebook/pull/4453
-    from notebook.utils import maybe_future
+    from jupyter_server.utils import maybe_future
 except ImportError:
     # We can't find it in `notebook` then we should be able to find it in Tornado
     from tornado.gen import maybe_future

--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -14,13 +14,7 @@ from tornado import gen, web, httpclient, httputil, process, websocket, ioloop, 
 from jupyter_server.utils import url_path_join
 from jupyter_server.base.handlers import JupyterHandler, utcnow
 
-try:
-    # Tornado 6.0 deprecated its `maybe_future` function so `notebook` made their own.
-    # See: https://github.com/jupyter/notebook/pull/4453
-    from jupyter_server.utils import maybe_future
-except ImportError:
-    # We can't find it in `notebook` then we should be able to find it in Tornado
-    from tornado.gen import maybe_future
+from jupyter_server.utils import ensure_async
 
 
 class PingableWSClientConnection(websocket.WebSocketClientConnection):
@@ -96,7 +90,7 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
         if self.request.headers.get("Upgrade", "").lower() != 'websocket':
             return await self.http_get(*args, **kwargs)
         else:
-            await maybe_future(super().get(*args, **kwargs))
+            await ensure_async(super().get(*args, **kwargs))
 
 
 def setup_handlers(web_app):

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,11 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
-    install_requires=["simpervisor>=0.4", "aiohttp"],
+    install_requires=[
+        "aiohttp",
+        "jupyter-server>=1.0",
+        "simpervisor>=0.4",
+    ],
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.6",

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -31,5 +31,6 @@ c.ServerProxy.servers = {
 
 import sys
 sys.path.append('./tests/resources')
+c.ServerApp.jpserver_extensions = { 'proxyextension': True }
 c.NotebookApp.nbserver_extensions = { 'proxyextension': True }
 #c.Application.log_level = 'DEBUG'

--- a/tests/resources/proxyextension.py
+++ b/tests/resources/proxyextension.py
@@ -1,5 +1,5 @@
 from jupyter_server_proxy.handlers import ProxyHandler
-from notebook.utils import url_path_join
+from jupyter_server.utils import url_path_join
 
 class NewHandler(ProxyHandler):
     async def http_get(self):

--- a/tests/resources/proxyextension.py
+++ b/tests/resources/proxyextension.py
@@ -35,13 +35,17 @@ class NewHandler(ProxyHandler):
         return super().proxy(host, port, proxied_path)
 
 
-def _jupyter_server_extension_paths():
-    return [{"module": "dask_labextension"}]
+def _jupyter_server_extension_points():
+    return [{"module": "proxyextension"}]
 
 
-def load_jupyter_server_extension(nb_server_app):
+def _load_jupyter_server_extension(nb_server_app):
     web_app = nb_server_app.web_app
     base_url = web_app.settings["base_url"]
     proxy_path = url_path_join(base_url, "newproxy/" + "?")
     handlers = [(proxy_path, NewHandler)]
     web_app.add_handlers(".*$", handlers)
+
+
+# For backward compatibility
+load_jupyter_server_extension = _load_jupyter_server_extension


### PR DESCRIPTION
This also includes a commit https://github.com/jupyterhub/jupyter-server-proxy/commit/171c8b89bb50541793883ceb2bb6852af442ab9c which should fix the `TypeError: object NoneType can't be used in 'await' expression` problem mentioned in
https://github.com/jupyterhub/jupyter-server-proxy/blob/885cf001a1d41791240400a64b6765a7aeca9a9f/tests/test_proxies.py#L69-L78

EDIT by Erik: Closes #109 I think