### PR TITLE
Fix PyPI url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ long_description = (HERE / "README.md").read_text()
 pkg_json = json.loads((HERE / "jupyterlab-server-proxy" / "package.json").read_bytes())
 
 setup_args = dict(
-    name=name,
+    name=name.replace("_", "-"),
     version=pkg_json["version"],
     url=pkg_json["homepage"],
     author=pkg_json["author"]["name"],


### PR DESCRIPTION
Closes #258 

```sh
$ ls dist
jupyter-server-proxy-3.0.0.tar.gz           jupyter_server_proxy-3.0.0-py3-none-any.whl
```

The `.tar.gz` file now has the correct name.