### PR TITLE
Include jupyterlab-server-proxy in the sdist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [3.0]
 
+### [3.0.2]
+
+#### Bugs fixed
+
+* Include `jupyterlab_server_proxy` in the source tarball.
+
 ### [3.0.1]
 
 #### Bugs fixed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+recursive-include jupyterlab-server-proxy *
 include LICENSE


### PR DESCRIPTION
This should fix the conda packaging issues in https://github.com/conda-forge/jupyter-server-proxy-feedstock/pull/20