### PR TITLE
Initialize icon_path when entry disabled

### DIFF
--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -33,7 +33,7 @@ def _load_jupyter_server_extension(nbapp):
 
     icons = {}
     for sp in server_processes:
-        if sp.launcher_entry.enabled and sp.launcher_entry.icon_path:
+        if sp.launcher_entry.icon_path:
             icons[sp.name] = sp.launcher_entry.icon_path
 
     nbapp.web_app.add_handlers('.*', [


### PR DESCRIPTION
Hi!
I am using the [jupyter-lmod](https://github.com/cmd-ntrf/jupyter-lmod) extension to dynamically load modules inside a Jupyter container.
The module is able to show/hide icons depending on the availability of the module/executable. For example, this prevents people to try launching RStudio, because they see the icon, if it's not loaded. In this mechanism, the launcher entry has to be set to "disabled" at the beginning (as the module is not loaded). The module takes care of dynamically adding the launcher entry.
However, with the current code, the icon path is not initialized when the module is not enabled from the beginning. And as it's impossible to add more handlers on the same path afterwards (unless I'm mistaken but I tried it multiple ways), the icon can never be displayed.
Proposed modification is to always initialize the icon_path when it's present, even if the entry is disabled. It does not cost much in the end, even if this icon/path is never used. And if the launcher entry is there, even if disabled, it must be for a good reason, so why not initialize the icon_path?