### PR TITLE
enable multiple launchers (with paths)

### DIFF
--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -34,8 +34,10 @@ def _load_jupyter_server_extension(nbapp):
     launcher_entries = []
     icons = {}
     for sp in server_processes:
-        if sp.launcher_entry.enabled and sp.launcher_entry.icon_path:
-            icons[sp.name] = sp.launcher_entry.icon_path
+        for le in sp.launcher_entries:
+            if le.enabled and le.icon_path:
+                icons[(sp.name, le.name)] = le.icon_path
+
 
     nbapp.web_app.add_handlers('.*', [
         (ujoin(base_url, 'server-proxy/servers-info'), ServersInfoHandler, {'server_processes': server_processes}),

--- a/jupyter_server_proxy/static/tree.js
+++ b/jupyter_server_proxy/static/tree.js
@@ -18,33 +18,34 @@ define(['jquery', 'base/js/namespace', 'base/js/utils'], function($, Jupyter, ut
                 .attr('role', 'presentation')
                 .addClass('divider');
 
-            
+
             /* add the divider */
             $menu.append($divider);
 
             $.each(data.server_processes, function(_, server_process) {
-                if (!server_process.launcher_entry.enabled) {
-                    return;
-                }
+                $.each(server_process.launcher_entries, function(_, launcher_entry) {
+                    if (!launcher_entry.enabled) {
+                        return;
+                    }
 
-                /* create our list item */
-                var $entry_container = $('<li>')
-                    .attr('role', 'presentation')
-                    .addClass('new-' + server_process.name);
+                    /* create our list item */
+                    var $entry_container = $('<li>')
+                        .attr('role', 'presentation')
+                        .addClass('new-' + server_process.name + '-' + launcher_entry.name);
 
-                /* create our list item's link */
-                var $entry_link = $('<a>')
-                    .attr('role', 'menuitem')
-                    .attr('tabindex', '-1')
-                    .attr('href', base_url + server_process.name + '/')
-                    .attr('target', '_blank')
-                    .text(server_process.launcher_entry.title);
+                    /* create our list item's link */
+                    var $entry_link = $('<a>')
+                        .attr('role', 'menuitem')
+                        .attr('tabindex', '-1')
+                        .attr('href', base_url + server_process.name + launcher_entry.path)
+                        .attr('target', '_blank')
+                        .text(launcher_entry.title);
 
-                /* add the link to the item and
-                * the item to the menu */
-                $entry_container.append($entry_link);
-                $menu.append($entry_container);
-
+                    /* add the link to the item and
+                    * the item to the menu */
+                    $entry_container.append($entry_link);
+                    $menu.append($entry_container);
+                });
             });
         });
     }

--- a/jupyterlab-server-proxy/package.json
+++ b/jupyterlab-server-proxy/package.json
@@ -41,18 +41,20 @@
     "install:extension": "jupyter labextension develop --overwrite .",
     "prepare": "jlpm run clean && jlpm run build:prod",
     "watch": "run-p watch:src watch:labextension",
-    "watch:src": "tsc -w",
+    "watch:src": "tsc -w --preserveWatchOutput",
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
     "@jupyterlab/application": "^2.0.0 || ^3.0.0",
     "@jupyterlab/apputils": "^2.0.0 || ^3.0.0",
-    "@jupyterlab/launcher": "^2.0.0 || ^3.0.0"
+    "@jupyterlab/launcher": "^2.0.0 || ^3.0.0",
+    "@jupyterlab/mainmenu": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^3.0.2",
-    "rimraf": "^2.6.1",
-    "typescript": "~3.7.0"
+    "rimraf": "^3.0.2",
+    "typescript": "~4.2.4",
+    "npm-run-all": "~4.1.5"
   },
   "jupyterlab": {
     "extension": true,


### PR DESCRIPTION
- fixes #266
- fixes #222

This reworks the configuration in a backwards-compatible way to enable multiple launchers from the same server process.

The public REST API would change (from `launcher_entry` to `launcher_entries`), as does the URL scheme for the icons `<server.name>/<launcher.name>`.

I opted not to do the submenus, but could.

Additionally, in lab, this makes launcher and layoutrestorer optional, and adds mainmenu and commandpalette, which _should_ make this compatible with jupyterlab-classic (though it wouldn't be exposed in the son-of-tree page, and is probably out of scope for this PR).

I didn't see where launcher_entry is under test, but am happy to add something if requested.