### PR TITLE
Proxying to servers based on Host: header (no path prefix)

### DIFF
--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -25,7 +25,9 @@ def _load_jupyter_server_extension(nbapp):
 
     server_processes = [make_server_process(k, v) for k, v in serverproxy.servers.items()]
     server_processes += get_entrypoint_server_processes()
-    server_handlers = make_handlers(base_url, server_processes)
+    server_handlers, virtualhosts = make_handlers(base_url, server_processes)
+    for host_pattern, handlers in virtualhosts:
+        nbapp.web_app.add_handlers(host_pattern, handlers)
     nbapp.web_app.add_handlers('.*', server_handlers)
 
     # Set up default handler

--- a/tests/resources/httpinfo.py
+++ b/tests/resources/httpinfo.py
@@ -8,6 +8,8 @@ class EchoRequestInfo(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write('{}\n'.format(self.requestline).encode())
         self.wfile.write('{}\n'.format(self.headers).encode())
+        if sys.argv[2:]:
+            self.wfile.write("X-Httpinfo-Args: {}\n".format(" ".join(sys.argv[2:])).encode())
 
 
 if __name__ == '__main__':

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -24,6 +24,27 @@ c.ServerProxy.servers = {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
         'mappath': mappathf,
     },
+    'python-http-vhost-default': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}', 'http-vhost-default'],
+        'virtualhost': {
+            'enabled': True,
+            # default pattern matches "python-http-vhost-default.<anydomain>"
+        }
+    },
+    'python-http-vhost-location': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}', 'http-vhost-location'],
+        'virtualhost': {
+            'enabled': True,
+            'location': 'flurble.127.0.0.1.nip.io',
+        }
+    },
+    'python-http-vhost-pattern': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}', 'http-vhost-pattern'],
+        'virtualhost': {
+            'enabled': True,
+            'host_pattern': '^.*[.]blah[.].*(:\d+)?$',
+        }
+    },
     'python-websocket' : {
         'command': ['python3', './tests/resources/websocket.py', '--port={port}'],
     },
@@ -38,5 +59,6 @@ c.ServerProxy.servers = {
 import sys
 sys.path.append('./tests/resources')
 c.ServerApp.jpserver_extensions = { 'proxyextension': True }
+c.ServerApp.allow_remote_access = True
 c.NotebookApp.nbserver_extensions = { 'proxyextension': True }
 #c.Application.log_level = 'DEBUG'


### PR DESCRIPTION
*(Please note: this isn't code to be merged yet!  Rather, I'm requesting a sanity check of my approach, and advice for the right way forward.  If you'd rather do this in a different forum, e.g. the Jupyter google group, then please let me know)*

-----

My goal is to integrate the GNS3 network emulator as a proxied application within JupyterHub.  The problem is that the HTML and Javascript emitted by GNS3 contains absolute paths, and it [can't be configured](https://github.com/GNS3/gns3-server/issues/1889) to prepend a prefix.  There are other applications like this, so I think this is a generally useful capability.

The approach I'm working on is to match the Host: header, i.e. "virtualhosts".  For example, you can configure `gns3.localdomain` to be proxied through to the GNS3 process; then there is no need for a path prefix like `/gns3/`.  For JupyterHub I'm thinking of hostname `student4.gns3.example.com` instead of `/user/student4/gns3/`.  This lets you configure a wildcard DNS entry (and even a wildcard certificate) for `*.gns3.example.com`.

The first step therefore is getting something to work with JupyterLab, and that's what this experimental patch contains.  The configuration looks like this:

        c.ServerProxy.servers = {
          'gns3': {
            'command': ['...'],
            'port': 3080,
            'virtualhost': {
                'enabled': True,
                'location': 'gns3.example.com',
            }
          }
        }

With this configuration:

* the server handler is registered under host pattern `^gns3\.example\.com$`, and does not modify the path
* a redirect handler is added for `{base_url}/gns3/.*` which redirects to `gns3.example.com`

You can specify the host_pattern explicitly if you wish.  If you omit both the location and host_pattern, then there is a hard-coded default (it will match `<any>.gns3.p.<any>`, and redirect to `gns3.p.<http-host>`)

This more-or-less works, and there are test cases.

The main rough edge is around authentication.  Cookies aren't shared between virtualhosts (although potentially they could, if the cookie was set with domain `*.example.com`).  What I'm doing for now is adding `?token=<token>` on the redirect target URL.  This exposes the token in the URL bar (yuk!), and of course won't work if a different form of authentication is being used.

I wouldn't mind if the user had to login a second time: however, that currently doesn't work.  If someone goes directly to `gns3.example.com` (e.g. because they bookmarked it), then there's an infinite redirect loop; as far as I can see, the virtualhost matching is taking precedence over the matching of `{base_url}/login`.  I'd very much appreciate advice on fixing this, as I'm not familiar with the Tornado web framework.

I also note that potentially some backend apps might use path `/login` for themselves, so for virtualhosts it might be a better to expose login at some other path, e.g. `/jupyter/login` or even `/<some-random-string>/login`.

Regarding the JupyterHub integration, I would also be grateful for clues here.  Presumably JupyterHub's proxy will also need to do virtualhost matching, but I haven't looked at that yet.

I also need to generate a redirect from e.g. `/user/student4/gns3/` to `student4.gns3.example.com`.  AFAICS this could be done at the JupyterLab side: tcpdump shows that the full path is included in the request to JupyterLab (as well as environment variable `JUPYTERHUB_SERVICE_PREFIX`).  But perhaps this logic would be better implemented at the JupyterHub side instead?  In which case, it might be an idea for JupyterHub to apply a header like `X-Jupyter-Server-Proxy: gns3` which would avoid any need for configuration on JupyterLab side - although it may still be useful to have this feature in JupyterLab standalone, if only for testing.

Many thanks for your help!