### PR TITLE
Feature/add launcher url

### DIFF
--- a/jupyter_server_proxy/api.py
+++ b/jupyter_server_proxy/api.py
@@ -20,7 +20,7 @@ class ServersInfoHandler(JupyterHandler):
                 'launcher_entry': {
                     'enabled': sp.launcher_entry.enabled,
                     'title': sp.launcher_entry.title,
-                    'launcher_url': sp.launcher_entry.launcher.url
+                    'launcher_url': sp.launcher_entry.launcher_url
                 },
                 'new_browser_tab' : sp.new_browser_tab
             }

--- a/jupyter_server_proxy/api.py
+++ b/jupyter_server_proxy/api.py
@@ -19,7 +19,8 @@ class ServersInfoHandler(JupyterHandler):
                 'name': sp.name,
                 'launcher_entry': {
                     'enabled': sp.launcher_entry.enabled,
-                    'title': sp.launcher_entry.title
+                    'title': sp.launcher_entry.title,
+                    'launcher_url': sp.launcher_entry.launcher.url
                 },
                 'new_browser_tab' : sp.new_browser_tab
             }

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -106,7 +106,7 @@ def make_handlers(base_url, server_processes):
         ))
     return handlers
 
-LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title'])
+LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title', 'launcher_url'])
 ServerProcess = namedtuple('ServerProcess', [
     'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'mappath', 'launcher_entry', 'new_browser_tab', 'request_headers_override'])
 
@@ -123,7 +123,8 @@ def make_server_process(name, server_process_config):
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),
             icon_path=le.get('icon_path'),
-            title=le.get('title', name)
+            title=le.get('title', name),
+            launcher_url=le.get('launcher_url', '/'),
         ),
         new_browser_tab=server_process_config.get('new_browser_tab', True),
         request_headers_override=server_process_config.get('request_headers_override', {})
@@ -182,6 +183,10 @@ class ServerProxy(Configurable):
 
             title
               Title to be used for the launcher entry. Defaults to the name of the server if missing.
+
+            launcher_url
+              URL path the launcher will point to. Relative to the proxied server. Defaults to '/' if missing.
+
 
           new_browser_tab
             Set to True (default) to make the proxied server interface opened as a new browser tab. Set to False

--- a/jupyter_server_proxy/static/tree.js
+++ b/jupyter_server_proxy/static/tree.js
@@ -36,7 +36,7 @@ define(['jquery', 'base/js/namespace', 'base/js/utils'], function($, Jupyter, ut
                 var $entry_link = $('<a>')
                     .attr('role', 'menuitem')
                     .attr('tabindex', '-1')
-                    .attr('href', base_url + server_process.name + '/')
+                    .attr('href', base_url + server_process.name + server_process.launcher_entry.launcher_url)
                     .attr('target', '_blank')
                     .text(server_process.launcher_entry.title);
 


### PR DESCRIPTION
This commit allows a provider of an proxied server to specify where the link in the launcher will point to.

Usually (and by default) this will be `/`, so the launcher can point to `{base_url} / {server_name} /`, however in some cases the entrypoint url to the launched service can be different (e.g.  `{base_url} / {server_name} / auth-sign-in` ...)