### PR TITLE
Add proxy_client_options

### DIFF
--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -150,6 +150,15 @@ pairs.
    * A callable that takes any :ref:`callable arguments <server-process/callable-argument>`,
      and returns a dictionary of strings that are used & treated same as above.
 
+``proxy_client_options``
+^^^^^^^^^^^^^^^
+
+   One of:
+
+   * A dictionary of arguments that are used to construct the proxy HTTP client.
+
+   * A callable that takes any :ref:`callable arguments <server-process/callable-argument>`,
+     and returns a dictionary of strings that are used & treated same as above.
 
 .. _server-processes/callable-arguments:
 

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -222,7 +222,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             else:
                 body = None
 
-        client = httpclient.AsyncHTTPClient()
+        client = httpclient.AsyncHTTPClient(**self.get_proxy_client_options())
 
         req = self._build_proxy_request(host, port, proxied_path, body)
 
@@ -336,6 +336,11 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
 
     def get_request_headers_override(self):
         '''Add additional request headers. Typically overridden in subclasses.'''
+        return {}
+
+    def get_proxy_client_options(self):
+        '''A dictionary of options to be used when constructing
+        a tornado.httpclient.AsyncHTTPClient for the proxy request.'''
         return {}
 
     def proxy_request_options(self):


### PR DESCRIPTION
Issue #281 Allow a per server process client configuration of the underlying HTTP
proxy client.

For example, the current web framework, Tornado, limits
the maximum body size to 100MiB which can restrict how much data
the proxy can request from the backend server process, e.g.
imagine proxying a storage interface like MinIO from within Jupyter.

Since this extension is not strictly limited to Tornado per se, the
"proxy_client_options" config is just a dictionary that gets passed in to
client as is.

Now with this changeset, the underlying httpclient.AsyncHTTPClient
can be configured like so:

```
'command': getsome_server_command(),
...
'proxy_client_options': {
	'max_body_size': 1024*1024*1024,
},
```