### PR TITLE
Apply `request_headers_override` to websocket requests

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -282,7 +282,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             proxied_path = '/' + proxied_path
 
         client_uri = self.get_client_uri('ws', host, port, proxied_path)
-        headers = self.request.headers
+        headers = self.proxy_request_headers()
         current_loop = ioloop.IOLoop.current()
         ws_connected = current_loop.asyncio_loop.create_future()
 

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -26,13 +26,16 @@ c.ServerProxy.servers = {
     },
     'python-websocket' : {
         'command': ['python3', './tests/resources/websocket.py', '--port={port}'],
+        'request_headers_override': {
+            'X-Custom-Header': 'pytest-23456',
+        }
     },
     'python-request-headers': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
         'request_headers_override': {
             'X-Custom-Header': 'pytest-23456',
         }
-    }
+    },
 }
 
 import sys

--- a/tests/resources/websocket.py
+++ b/tests/resources/websocket.py
@@ -39,6 +39,7 @@ class Application(tornado.web.Application):
             (r"/", MainHandler),
             (r"/echosocket", EchoWebSocket),
             (r"/subprotocolsocket", SubprotocolWebSocket),
+            (r"/headerssocket", HeadersWebSocket),
         ]
         settings = dict(
             cookie_secret="__RANDOM_VALUE__",
@@ -57,6 +58,11 @@ class MainHandler(tornado.web.RequestHandler):
 class EchoWebSocket(tornado.websocket.WebSocketHandler):
     def on_message(self, message):
         self.write_message(message)
+
+
+class HeadersWebSocket(tornado.websocket.WebSocketHandler):
+    def on_message(self, message):
+        self.write_message(json.dumps(dict(self.request.headers)))
 
 
 class SubprotocolWebSocket(tornado.websocket.WebSocketHandler):

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -210,8 +210,23 @@ async def _websocket_echo():
     msg = await conn.read_message()
     assert msg == expected_msg
 
+
 def test_server_proxy_websocket(event_loop):
     event_loop.run_until_complete(_websocket_echo())
+
+
+async def _websocket_headers():
+    url = "ws://localhost:{}/python-websocket/headerssocket".format(PORT)
+    conn = await websocket_connect(url)
+    await conn.write_message("Hello")
+    msg = await conn.read_message()
+    headers = json.loads(msg)
+    assert 'X-Custom-Header' in headers
+    assert headers['X-Custom-Header'] == 'pytest-23456'
+
+
+def test_server_proxy_websocket_headers(event_loop):
+    event_loop.run_until_complete(_websocket_headers())
 
 
 async def _websocket_subprotocols():


### PR DESCRIPTION
Fixes #286