### PR TITLE
Fix link to contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ jupyter labextension install @jupyterlab/server-proxy
 
 ## Local development
 
-See [CONTRIBUTING.md].
+See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Hi, was reading about it after a friend pointed `jupyter-server-proxy`. The `CONTRIBUTING.md` link is not rendered on GitHub UI. Not sure if there's some way to auto link the file in Markdown, or if it was supposed to be a link but just missed the final part?

Thanks!