### PR TITLE
Simplify wait logic for websocket connection

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -283,8 +283,6 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
 
         client_uri = self.get_client_uri('ws', host, port, proxied_path)
         headers = self.proxy_request_headers()
-        current_loop = ioloop.IOLoop.current()
-        ws_connected = current_loop.asyncio_loop.create_future()
 
         def message_cb(message):
             """
@@ -316,15 +314,13 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             self.ws = await pingable_ws_connect(request=request,
                 on_message_callback=message_cb, on_ping_callback=ping_cb,
                 subprotocols=self.subprotocols)
-            ws_connected.set_result(True)
             self._record_activity()
             self.log.info('Websocket connection established to {}'.format(client_uri))
 
-        current_loop.add_callback(start_websocket_connection)
         # Wait for the WebSocket to be connected before resolving.
         # Otherwise, messages sent by the client before the
         # WebSocket successful connection would be dropped.
-        await ws_connected
+        await start_websocket_connection()
 
     def proxy_request_headers(self):
         '''A dictionary of headers to be used when constructing


### PR DESCRIPTION
I'm using this package in an environment that happens to have an older version of Tornado. When I attempted to open a Websocket connection through the proxy I experienced this traceback:
```
Traceback (most recent call last):
  File "<ENV>/lib/python3.7/site-packages/tornado/web.py", line 1468, in _stack_context_handle_exception
    raise_exc_info((type, value, traceback))
  File "<string>", line 4, in raise_exc_info
  File "<ENV>/lib/python3.7/site-packages/tornado/stack_context.py", line 316, in wrapped
    ret = fn(*args, **kwargs)
  File "<ENV>/lib/python3.7/site-packages/tornado/websocket.py", line 502, in <lambda>
    self.stream.io_loop.add_future(result, lambda f: f.result())
  File "<ENV>/lib/python3.7/site-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "<ENV>/lib/python3.7/site-packages/tornado/gen.py", line 307, in wrapper
    yielded = next(result)
  File "<string>", line 6, in _wrap_awaitable
  File "<ENV>/lib/python3.7/site-packages/jupyter_server_proxy/handlers.py", line 367, in open
    return await self.proxy_open('localhost', port, proxied_path)
  File "<ENV>/lib/python3.7/site-packages/jupyter_server_proxy/handlers.py", line 287, in proxy_open
    ws_connected = current_loop.asyncio_loop.create_future()
AttributeError: 'ZMQIOLoop' object has no attribute 'asyncio_loop'
```
In discussions with a colleague the cause here is the use of Tornado 6 logic. For... reasons I needed to investigate a way to restore functionality with Tornado 4.

When I looked at this code, however, I realized that I really couldn't understand why a Future-based approach was taken here. In short, the current code:
1. Creates a future
2. Creates a callback that completes Future when it is completed
3. Launches the callback
4. Waits for the future

But given that the only consumer of the future is this one function, it is not clear to me why this is not equivalent to a simple `await` of the callback.

I've tested this live, and I'm back in business. So I intend to use this myself, and I wanted to offer it here.  And while Tornado 4 compatibility might not be a priority, it seems like an easy win regardless simply on the basis of code simplificaiton.

However, if you choose to reject this for technical reasons I would be delighted to understand them, because I'm worried that I'm missing something!