### PR TITLE
fix path_info for JupyterLab

### DIFF
--- a/jupyterlab-server-proxy/src/index.ts
+++ b/jupyterlab-server-proxy/src/index.ts
@@ -80,7 +80,7 @@ async function activate(app: JupyterFrontEnd, launcher: ILauncher, restorer: ILa
       continue;
     }
 
-    const url = PageConfig.getBaseUrl() + server_process.name + '/';
+    const url = PageConfig.getBaseUrl() + server_process.launcher_entry.path_info;
     const title = server_process.launcher_entry.title;
     const newBrowserTab = server_process.new_browser_tab;
     const id = namespace + ':' + server_process.name;


### PR DESCRIPTION
The new possibility to define a `path_info` was added a few month ago.  
A click on a JupyterLab launcher icon currently does not respect it. This MR fixes the issue.