### PR TITLE
propagate check_origin of JupyterHandler to enable CORS websocket access

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -51,6 +51,12 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         self.subprotocols = None
         super().__init__(*args, **kwargs)
 
+    # Support/use jupyter_server config arguments allow_origin and allow_origin_pat
+    # to enable cross origin requests propagated by e.g. inverting proxies.
+
+    def check_origin(self, origin=None):
+        return JupyterHandler.check_origin(self, origin)
+
     # Support all the methods that tornado does by default except for GET which
     # is passed to WebSocketHandlerMixin and then to WebSocketHandler.
 


### PR DESCRIPTION
Thanks for this extremly helpful package. Exposing applications like `code-server` using `jupyter-vscode-proxy` via an inverting proxy e.g. `gcr.io/inverting-proxy` fails due to not allowed cross origin websockets. This seccurity rule was  introduced in `tornado>=4` see [`check_origin`](https://github.com/tornadoweb/tornado/blob/2047e7ae3c825bf52dad10cc8402d09e11091bc1/tornado/websocket.py#L489) and its doc string. `jupyter-server` provides a configurable `check_origin` function consuming `allow_origin` and `allow_origin_pat` being very fine tunable cross origin permissions. This PR exposes the `jupyter-server-proxy` to this functionality and being similar configured as the `jupyter-server` regarding cross origin acceptance. 

Please comment/review I'm open to suggestions and feedback.  