### PR TITLE
fix: do not follow redirects when checking if server is up

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -491,7 +491,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
         url = 'http://localhost:{}'.format(self.port)
         async with aiohttp.ClientSession() as session:
             try:
-                async with session.get(url) as resp:
+                async with session.get(url, allow_redirects=False) as resp:
                     # We only care if we get back *any* response, not just 200
                     # If there's an error response, that can be shown directly to the user
                     self.log.debug('Got code {} back from {}'.format(resp.status, url))


### PR DESCRIPTION
When simply checking if the server that we're proxying to is up, I think it would make sense to not follow redirects and just interpret redirection as success. In my case this fixed an infinite redirection loop which occurred when proxying to an Rstudio server.