### PR TITLE
Enable rewrite_response to modify status and headers

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -136,7 +136,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
         request_headers_override=server_process_config.get('request_headers_override', {}),
         rewrite_response=server_process_config.get(
             'rewrite_response',
-            lambda host, port, path, response: response.body
+            lambda host, port, path, response: {}
         ),
     )
 
@@ -212,22 +212,22 @@ class ServerProxy(Configurable):
             port ``port``, the ``path`` from the requested URL, and
             ``response`` is a `tornado.httpclient.HTTPResponse object
             <https://www.tornadoweb.org/en/stable/httpclient.html#response-objects>`.
-            Output is bytes.
-            Defaults to ``lambda host, port, path, response: response.body``.
+            Output is a dictionary with optional keys for "code", "reason", "headers", and "body". If a key is unspecified, the corresponding response value will not be altered. The value types match those in a `tornado.httpclient.HTTPResponse` object.
+            Defaults to ``lambda host, port, path, response: {}``.
         """,
         config=True
     )
 
     non_service_rewrite_response = Callable(
-        lambda host, port, path, response: response.body,
+        lambda host, port, path, response: {},
         help="""
         A function to rewrite the response for a non-service request, for
         example a request to ``/proxy/<host>:<port><path>``. Input arguments
         ``host``, ``port``, and ``path`` come from the requested URL, and
         "response" is a `tornado.httpclient.HTTPResponse object
         <https://www.tornadoweb.org/en/stable/httpclient.html#response-objects>`.
-        Output is bytes.
-        Defaults to ``lambda host, port, path, response: response.body``.
+        See the description for ``rewrite_response`` for more information.
+        Defaults to ``lambda host, port, path, response: {}``.
         """,
         config=True
     )

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -136,7 +136,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
         request_headers_override=server_process_config.get('request_headers_override', {}),
         rewrite_response=server_process_config.get(
             'rewrite_response',
-            lambda host, port, path, response: {}
+            lambda request, host, port, path, response: {}
         ),
     )
 
@@ -208,26 +208,25 @@ class ServerProxy(Configurable):
 
           rewrite_response
             An optional function to rewrite the response for the given service.
-            Input arguments are ``host`` which is ``"localhost"``, the service
-            port ``port``, the ``path`` from the requested URL, and
-            ``response`` is a `tornado.httpclient.HTTPResponse object
+            Input arguments are the proxy handler's ``request`` object, ``host``
+            which is ``"localhost"``, the service port ``port``, the ``path``
+            from the requested URL, and ``response`` is a
+            `tornado.httpclient.HTTPResponse object
             <https://www.tornadoweb.org/en/stable/httpclient.html#response-objects>`.
             Output is a dictionary with optional keys for "code", "reason", "headers", and "body". If a key is unspecified, the corresponding response value will not be altered. The value types match those in a `tornado.httpclient.HTTPResponse` object.
-            Defaults to ``lambda host, port, path, response: {}``.
+            Defaults to ``lambda request, host, port, path, response: {}``.
         """,
         config=True
     )
 
     non_service_rewrite_response = Callable(
-        lambda host, port, path, response: {},
+        lambda request, host, port, path, response: {},
         help="""
         A function to rewrite the response for a non-service request, for
-        example a request to ``/proxy/<host>:<port><path>``. Input arguments
-        ``host``, ``port``, and ``path`` come from the requested URL, and
-        "response" is a `tornado.httpclient.HTTPResponse object
-        <https://www.tornadoweb.org/en/stable/httpclient.html#response-objects>`.
+        example a request to ``/proxy/<host>:<port><path>``.
+
         See the description for ``rewrite_response`` for more information.
-        Defaults to ``lambda host, port, path, response: {}``.
+        Defaults to ``lambda request, host, port, path, response: {}``.
         """,
         config=True
     )

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -46,7 +46,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         self.host_allowlist = kwargs.pop('host_allowlist', ['localhost', '127.0.0.1'])
         self.rewrite_response = kwargs.pop(
             'rewrite_response',
-            lambda host, port, path, response: {}
+            lambda request, host, port, path, response: {}
         )
         self.subprotocols = None
         super().__init__(*args, **kwargs)
@@ -257,10 +257,10 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         else:
             # self.rewrite_response returns a dict of 'code', 'reason',
             # 'headers', and 'body'. The function definition is
-            #   lambda host, port, path, response: {}
+            #   lambda request, host, base_url, port, path, response: {}
             # unless overridden in configuration.
             rewritten_response = self.rewrite_response(
-                host, port, proxied_path, response
+                self.request, host, port, proxied_path, response
             )
 
             ## status

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -5,7 +5,6 @@ def mappathf(path):
 c.ServerProxy.servers = {
     'python-http': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
-        'rewrite_response': lambda host, port, path, response: response.body.replace(b"ciao", b"hello")
     },
     'python-http-abs': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
@@ -40,10 +39,14 @@ c.ServerProxy.servers = {
     'python-gzipserver': {
         'command': ['python3', './tests/resources/gzipserver.py', '{port}'],
     },
+    'python-http-rewrite-response': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'rewrite_response': lambda host, port, path, response: dict(body=response.body.replace(b"ciao", b"hello"))
+    },
 }
 
 c.ServerProxy.non_service_rewrite_response = \
-    lambda host, port, path, response: response.body.replace(b"bar", b"foo")
+    lambda host, port, path, response: dict(body=response.body.replace(b"bar", b"foo"))
 
 import sys
 sys.path.append('./tests/resources')

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -41,12 +41,12 @@ c.ServerProxy.servers = {
     },
     'python-http-rewrite-response': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
-        'rewrite_response': lambda host, port, path, response: dict(body=response.body.replace(b"ciao", b"hello"))
+        'rewrite_response': lambda request, host, port, path, response: dict(body=response.body.replace(b"ciao", b"hello"))
     },
 }
 
 c.ServerProxy.non_service_rewrite_response = \
-    lambda host, port, path, response: dict(body=response.body.replace(b"bar", b"foo"))
+    lambda request, host, port, path, response: dict(body=response.body.replace(b"bar", b"foo"))
 
 import sys
 sys.path.append('./tests/resources')

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -87,7 +87,7 @@ def test_server_proxy_hash_sign_encoding():
 
 
 def test_server_rewrite_response():
-    r = request_get(PORT, '/python-http/ciao-a-tutti', TOKEN)
+    r = request_get(PORT, '/python-http-rewrite-response/ciao-a-tutti', TOKEN)
     assert r.code == 200
     s = r.read().decode('ascii')
     assert s.startswith('GET /hello-a-tutti?token=')


### PR DESCRIPTION
This builds on @maresb 's work in #209 and enables one to also alter response HTTP headers and status code/reason.  Thanks to @yuvipanda for the idea!