### PR TITLE
Class-based rewrite response

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -209,20 +209,22 @@ class ServerProxy(Configurable):
 
           rewrite_response
             An optional function to rewrite the response for the given service.
-            Input is a RewritableResponse object. The function should modify one or
-            more of the attributes ``.body``, ``.headers``, ``.code``, or ``.reason``.
-            For example:
+            Input is a RewritableResponse object which is an argument that MUST be named
+            ``response``. The function should modify one or more of the attributes
+            ``.body``, ``.headers``, ``.code``, or ``.reason`` of the ``response``
+            argument. For example:
 
                 def cat_to_dog(response):
                     response.body = response.body.replace(b'cat', b'dog')
 
                 c.ServerProxy.servers['my_server']['rewrite_response'] = cat_to_dog
 
-            The RewritableRespone object also has attributes ``.host``, ``.port``, and
-            ``.path`` corresponding to the URL ``/proxy/<host>:<port><path>``. In
+            The ``rewrite_response`` function can also accept several optional
+            positional arguments. Arguments named ``host``, ``port``, and ``path`` will
+            receive values corresponding to the URL ``/proxy/<host>:<port><path>``. In
             addition, the original Tornado ``HTTPRequest`` and ``HTTPResponse`` objects
-            are available as ``.raw_request`` and ``.raw_response``. (These attributes
-            should not be modified.)
+            are available as arguments named ``orig_request`` and ``orig_response``.
+            (These objects should not be modified.)
 
             A list or tuple of functions can also be specified for chaining multiple
             rewrites.

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -136,7 +136,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
         request_headers_override=server_process_config.get('request_headers_override', {}),
         rewrite_response=server_process_config.get(
             'rewrite_response',
-            lambda host, port, path, response: response.body
+            lambda host, port, path, response: {}
         ),
     )
 
@@ -212,22 +212,22 @@ class ServerProxy(Configurable):
             port ``port``, the ``path`` from the requested URL, and
             ``response`` is a `tornado.httpclient.HTTPResponse object
             <https://www.tornadoweb.org/en/stable/httpclient.html#response-objects>`.
-            Output is bytes.
-            Defaults to ``lambda host, port, path, response: response.body``.
+            Output is a dictionary with optional keys for "code", "reason", "headers", and "body". If a key is unspecified, the corresponding response value will not be altered. The value types match those in a `tornado.httpclient.HTTPResponse` object.
+            Defaults to ``lambda host, port, path, response: {}``.
         """,
         config=True
     )
 
     non_service_rewrite_response = Callable(
-        lambda host, port, path, response: response.body,
+        lambda host, port, path, response: {},
         help="""
         A function to rewrite the response for a non-service request, for
         example a request to ``/proxy/<host>:<port><path>``. Input arguments
         ``host``, ``port``, and ``path`` come from the requested URL, and
         "response" is a `tornado.httpclient.HTTPResponse object
         <https://www.tornadoweb.org/en/stable/httpclient.html#response-objects>`.
-        Output is bytes.
-        Defaults to ``lambda host, port, path, response: response.body``.
+        See the description for ``rewrite_response`` for more information.
+        Defaults to ``lambda host, port, path, response: {}``.
         """,
         config=True
     )

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -223,8 +223,8 @@ class ServerProxy(Configurable):
             positional arguments. Arguments named ``host``, ``port``, and ``path`` will
             receive values corresponding to the URL ``/proxy/<host>:<port><path>``. In
             addition, the original Tornado ``HTTPRequest`` and ``HTTPResponse`` objects
-            are available as arguments named ``orig_request`` and ``orig_response``.
-            (These objects should not be modified.)
+            are available as arguments named ``request`` and ``orig_response``. (These
+            objects should not be modified.)
 
             A list or tuple of functions can also be specified for chaining multiple
             rewrites.

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -215,6 +215,7 @@ class ServerProxy(Configurable):
             argument. For example:
 
                 def cat_to_dog(response):
+                    response.headers["I-Like"] = "tacos"
                     response.body = response.body.replace(b'cat', b'dog')
 
                 c.ServerProxy.servers['my_server']['rewrite_response'] = cat_to_dog

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -136,7 +136,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
         request_headers_override=server_process_config.get('request_headers_override', {}),
         rewrite_response=server_process_config.get(
             'rewrite_response',
-            lambda host, port, path, response: {}
+            lambda request, host, port, path, response: {}
         ),
     )
 
@@ -208,26 +208,25 @@ class ServerProxy(Configurable):
 
           rewrite_response
             An optional function to rewrite the response for the given service.
-            Input arguments are ``host`` which is ``"localhost"``, the service
-            port ``port``, the ``path`` from the requested URL, and
-            ``response`` is a `tornado.httpclient.HTTPResponse object
+            Input arguments are the proxy handler's ``request`` object, ``host``
+            which is ``"localhost"``, the service port ``port``, the ``path``
+            from the requested URL, and ``response`` is a
+            `tornado.httpclient.HTTPResponse object
             <https://www.tornadoweb.org/en/stable/httpclient.html#response-objects>`.
             Output is a dictionary with optional keys for "code", "reason", "headers", and "body". If a key is unspecified, the corresponding response value will not be altered. The value types match those in a `tornado.httpclient.HTTPResponse` object.
-            Defaults to ``lambda host, port, path, response: {}``.
+            Defaults to ``lambda request, host, port, path, response: {}``.
         """,
         config=True
     )
 
     non_service_rewrite_response = Callable(
-        lambda host, port, path, response: {},
+        lambda request, host, port, path, response: {},
         help="""
         A function to rewrite the response for a non-service request, for
-        example a request to ``/proxy/<host>:<port><path>``. Input arguments
-        ``host``, ``port``, and ``path`` come from the requested URL, and
-        "response" is a `tornado.httpclient.HTTPResponse object
-        <https://www.tornadoweb.org/en/stable/httpclient.html#response-objects>`.
+        example a request to ``/proxy/<host>:<port><path>``.
+
         See the description for ``rewrite_response`` for more information.
-        Defaults to ``lambda host, port, path, response: {}``.
+        Defaults to ``lambda request, host, port, path, response: {}``.
         """,
         config=True
     )

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -210,7 +210,7 @@ class ServerProxy(Configurable):
           rewrite_response
             An optional function to rewrite the response for the given service.
             Input is a RewritableResponse object. The function should modify one or
-            more of the attributes ``body``, ``headers``, ``code``, or ``reason``.
+            more of the attributes ``.body``, ``.headers``, ``.code``, or ``.reason``.
             For example:
 
                 def cat_to_dog(response):
@@ -218,10 +218,13 @@ class ServerProxy(Configurable):
 
                 c.ServerProxy.servers['my_server']['rewrite_response'] = cat_to_dog
 
-            The RewritableRespone object also has attributes ``host``, ``port``, and
-            ``path`` corresponding to the URL ``/proxy/<host>:<port><path>``.
+            The RewritableRespone object also has attributes ``.host``, ``.port``, and
+            ``.path`` corresponding to the URL ``/proxy/<host>:<port><path>``. In
+            addition, the original Tornado ``HTTPRequest`` and ``HTTPResponse`` objects
+            are available as ``.raw_request`` and ``.raw_response``. (These attributes
+            should not be modified.)
 
-            A list or tuple of functions can also be specified for multiple
+            A list or tuple of functions can also be specified for chaining multiple
             rewrites.
 
             Defaults to the empty tuple ``tuple()``.

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -85,7 +85,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         self.host_allowlist = kwargs.pop('host_allowlist', ['localhost', '127.0.0.1'])
         self.rewrite_response = kwargs.pop(
             'rewrite_response',
-            lambda response: None,
+            tuple(),
         )
         self.subprotocols = None
         super().__init__(*args, **kwargs)
@@ -300,8 +300,11 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
                 port=port,
                 path=proxied_path
             )
-            # Rewrite the original response by mutation
-            self.rewrite_response(rewritable_response)
+            rewrite_response = self.rewrite_response
+            if not isinstance(rewrite_response, (list, tuple)):
+                rewrite_response = [rewrite_response]
+            for rewrite in rewrite_response:
+                rewrite(rewritable_response)
 
             ## status
             self.set_status(rewritable_response.code, rewritable_response.reason)

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -46,7 +46,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         self.host_allowlist = kwargs.pop('host_allowlist', ['localhost', '127.0.0.1'])
         self.rewrite_response = kwargs.pop(
             'rewrite_response',
-            lambda host, port, path, response: {}
+            lambda request, host, port, path, response: {}
         )
         self.subprotocols = None
         super().__init__(*args, **kwargs)
@@ -257,10 +257,10 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         else:
             # self.rewrite_response returns a dict of 'code', 'reason',
             # 'headers', and 'body'. The function definition is
-            #   lambda host, port, path, response: {}
+            #   lambda request, host, base_url, port, path, response: {}
             # unless overridden in configuration.
             rewritten_response = self.rewrite_response(
-                host, port, proxied_path, response
+                self.request, host, port, proxied_path, response
             )
 
             ## status

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -312,7 +312,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
 
             # To be passed on-demand as args to the rewrite_response functions.
             optional_args_to_rewrite_function = {
-                'request': req,
+                'request': self.request,
                 'orig_response': original_response,
                 'host': host,
                 'port': port,

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -312,7 +312,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
 
             # To be passed on-demand as args to the rewrite_response functions.
             optional_args_to_rewrite_function = {
-                'orig_request': req,
+                'request': req,
                 'orig_response': original_response,
                 'host': host,
                 'port': port,

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -10,6 +10,7 @@ import os
 from urllib.parse import urlunparse, urlparse, quote
 import aiohttp
 from asyncio import Lock
+from copy import copy
 
 from tornado import gen, web, httpclient, httputil, process, websocket, ioloop, version_info
 
@@ -63,14 +64,9 @@ class RewritableResponse(HasTraits):
         """
         Apply a function to a copy of self, and return the copy
         """
-        new = self._copy()
+        new = copy(self)
         func(new)
         return new
-
-    def _copy(self):
-        return RewritableResponse(
-            **{name: getattr(self, name) for name in self.traits()}
-        )
 
 
 class AddSlashHandler(JupyterHandler):

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -2,7 +2,10 @@ def mappathf(path):
     p = path + 'mapped'
     return p
 
-def translate_ciao(path, host, response, port):
+def translate_ciao(path, host, response, orig_response, port):
+    # Assume that the body has not been modified by any previous rewrite
+    assert response.body == orig_response.body
+
     response.code = 418
     response.reason = "I'm a teapot"
     response.headers["i-like"] = "tacos"

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -10,8 +10,8 @@ def translate_ciao(path, host, response, port):
     response.headers["Proxied-Path"] = path
     response.body = response.body.replace(b"ciao", b"hello")
 
-def bar_to_foo(response):
-    response.body = response.body.replace(b"bar", b"foo")
+def hello_to_foo(path, host, response, port):
+    response.body = response.body.replace(b"hello", b"foo")
 
 c.ServerProxy.servers = {
     'python-http': {
@@ -53,10 +53,15 @@ c.ServerProxy.servers = {
     'python-http-rewrite-response': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
         'rewrite_response': translate_ciao,
+        'port': 54323,
+    },
+    'python-chained-rewrite-response': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'rewrite_response': [translate_ciao, hello_to_foo],
     },
 }
 
-c.ServerProxy.non_service_rewrite_response = bar_to_foo
+c.ServerProxy.non_service_rewrite_response = hello_to_foo
 
 import sys
 sys.path.append('./tests/resources')

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -2,6 +2,12 @@ def mappathf(path):
     p = path + 'mapped'
     return p
 
+def translate_ciao(response):
+    response.body = response.body.replace(b"ciao", b"hello")
+
+def bar_to_foo(response):
+    response.body = response.body.replace(b"bar", b"foo")
+
 c.ServerProxy.servers = {
     'python-http': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
@@ -41,12 +47,11 @@ c.ServerProxy.servers = {
     },
     'python-http-rewrite-response': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
-        'rewrite_response': lambda request, host, port, path, response: dict(body=response.body.replace(b"ciao", b"hello"))
+        'rewrite_response': translate_ciao,
     },
 }
 
-c.ServerProxy.non_service_rewrite_response = \
-    lambda request, host, port, path, response: dict(body=response.body.replace(b"bar", b"foo"))
+c.ServerProxy.non_service_rewrite_response = bar_to_foo
 
 import sys
 sys.path.append('./tests/resources')

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -5,7 +5,6 @@ def mappathf(path):
 c.ServerProxy.servers = {
     'python-http': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
-        'rewrite_response': lambda host, port, path, response: response.body.replace(b"ciao", b"hello")
     },
     'python-http-abs': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
@@ -40,10 +39,14 @@ c.ServerProxy.servers = {
     'python-gzipserver': {
         'command': ['python3', './tests/resources/gzipserver.py', '{port}'],
     },
+    'python-http-rewrite-response': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'rewrite_response': lambda host, port, path, response: dict(body=response.body.replace(b"ciao", b"hello"))
+    },
 }
 
 c.ServerProxy.non_service_rewrite_response = \
-    lambda host, port, path, response: response.body.replace(b"bar", b"foo")
+    lambda host, port, path, response: dict(body=response.body.replace(b"bar", b"foo"))
 
 import sys
 sys.path.append('./tests/resources')

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -41,12 +41,12 @@ c.ServerProxy.servers = {
     },
     'python-http-rewrite-response': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
-        'rewrite_response': lambda host, port, path, response: dict(body=response.body.replace(b"ciao", b"hello"))
+        'rewrite_response': lambda request, host, port, path, response: dict(body=response.body.replace(b"ciao", b"hello"))
     },
 }
 
 c.ServerProxy.non_service_rewrite_response = \
-    lambda host, port, path, response: dict(body=response.body.replace(b"bar", b"foo"))
+    lambda request, host, port, path, response: dict(body=response.body.replace(b"bar", b"foo"))
 
 import sys
 sys.path.append('./tests/resources')

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -2,7 +2,12 @@ def mappathf(path):
     p = path + 'mapped'
     return p
 
-def translate_ciao(response):
+def translate_ciao(path, host, response, port):
+    response.code = 418
+    response.reason = "I'm a teapot"
+    response.headers["i-like"] = "tacos"
+    response.headers["Proxied-Host-Port"] = f"{host}:{port}"
+    response.headers["Proxied-Path"] = path
     response.body = response.body.replace(b"ciao", b"hello")
 
 def bar_to_foo(response):

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -88,7 +88,11 @@ def test_server_proxy_hash_sign_encoding():
 
 def test_server_rewrite_response():
     r = request_get(PORT, '/python-http-rewrite-response/ciao-a-tutti', TOKEN)
-    assert r.code == 200
+    assert r.code == 418
+    assert r.reason == "I'm a teapot"
+    assert ("I-Like", "tacos") in r.headers.items()
+    assert ("Proxied-Host-Port", "localhost:54323") in r.headers.items()
+    assert ("Proxied-Path", "/ciao-a-tutti") in r.headers.items()
     s = r.read().decode('ascii')
     assert s.startswith('GET /hello-a-tutti?token=')
 

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -97,6 +97,14 @@ def test_server_rewrite_response():
     assert s.startswith('GET /hello-a-tutti?token=')
 
 
+def test_chained_rewrite_response():
+    r = request_get(PORT, '/python-chained-rewrite-response/ciao-a-tutti', TOKEN)
+    assert r.code == 418
+    assert r.reason == "I'm a teapot"
+    s = r.read().decode('ascii')
+    assert s.startswith('GET /foo-a-tutti?token=')
+
+
 def test_server_proxy_non_absolute():
     r = request_get(PORT, '/python-http/abc', TOKEN)
     assert r.code == 200
@@ -164,11 +172,11 @@ def test_server_proxy_host_absolute():
     assert 'X-Proxycontextpath' not in s
 
 def test_server_proxy_port_non_service_rewrite_response():
-    """Test that 'bar' is replaced by 'foo'."""
-    r = request_get(PORT, '/proxy/54321/baz-bar-foo', TOKEN)
+    """Test that 'hello' is replaced by 'foo'."""
+    r = request_get(PORT, '/proxy/54321/hello', TOKEN)
     assert r.code == 200
     s = r.read().decode('ascii')
-    assert s.startswith('GET /baz-foo-foo?token=')
+    assert s.startswith('GET /foo?token=')
 
 
 @pytest.mark.parametrize(

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -87,7 +87,7 @@ def test_server_proxy_hash_sign_encoding():
 
 
 def test_server_rewrite_response():
-    r = request_get(PORT, '/python-http/ciao-a-tutti', TOKEN)
+    r = request_get(PORT, '/python-http-rewrite-response/ciao-a-tutti', TOKEN)
     assert r.code == 200
     s = r.read().decode('ascii')
     assert s.startswith('GET /hello-a-tutti?token=')


### PR DESCRIPTION
Building on #300, illustrating my idea of implementing a `RewritableResponse` class. I tried to use Traitlets to make my data class, since it's used throughout the Jupyter ecosystem, but I don't know it very well.

I was originally thinking of having `RewritableResponse` be the *return* type as well as the input type, but I found this awkward. Now I have `rewrite_response` mutating the `RewritableResponse` object. ~~But this makes the variable names a bit awkward... in order for the variable names to make sense, I now define `original_response` run `rewrite_response(original_response)`, define `rewritten_response` as `original_response` and then delete `original_response`. There must be a better way which I'm not seeing at the moment.~~