### PR TITLE
Set reason according to response code

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -214,11 +214,11 @@ class ServerProxy(Configurable):
             ``.body``, ``.headers``, ``.code``, or ``.reason`` of the ``response``
             argument. For example:
 
-                def cat_to_dog(response):
+                def dog_to_cat(response):
                     response.headers["I-Like"] = "tacos"
-                    response.body = response.body.replace(b'cat', b'dog')
+                    response.body = response.body.replace(b'dog', b'cat')
 
-                c.ServerProxy.servers['my_server']['rewrite_response'] = cat_to_dog
+                c.ServerProxy.servers['my_server']['rewrite_response'] = dog_to_cat
 
             The ``rewrite_response`` function can also accept several optional
             positional arguments. Arguments named ``host``, ``port``, and ``path`` will
@@ -228,7 +228,17 @@ class ServerProxy(Configurable):
             objects should not be modified.)
 
             A list or tuple of functions can also be specified for chaining multiple
-            rewrites.
+            rewrites. For example:
+
+                def cats_only(response, path):
+                    if path.startswith("/cat-club"):
+                        response.code = 403
+                        response.body = b"dogs not allowed"
+
+                c.ServerProxy.servers['my_server']['rewrite_response'] = [dog_to_cat, cats_only]
+
+            Note that if the order is reversed to ``[cats_only, dog_to_cat]``, accessing
+            ``/cat-club`` will produce a body with "cats not allowed" instead of "dogs not allowed".
 
             Defaults to the empty tuple ``tuple()``.
         """,

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -237,8 +237,9 @@ class ServerProxy(Configurable):
 
                 c.ServerProxy.servers['my_server']['rewrite_response'] = [dog_to_cat, cats_only]
 
-            Note that if the order is reversed to ``[cats_only, dog_to_cat]``, accessing
-            ``/cat-club`` will produce a body with "cats not allowed" instead of "dogs not allowed".
+            Note that if the order is reversed to ``[cats_only, dog_to_cat]``, then accessing
+            ``/cat-club`` will produce a "403 Forbidden" response with body "cats not allowed"
+            instead of "dogs not allowed".
 
             Defaults to the empty tuple ``tuple()``.
         """,

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -56,11 +56,16 @@ class RewritableResponse(HasTraits):
 
     @observe('code')
     def _observe_code(self, change):
-        # Automatically update reason if code changes and previous reason was default.
-        old_default_reason = httputil.responses.get(change['old'], 'Unknown')
-        new_default_reason = httputil.responses.get(change['new'], 'Unknown')
-        if self.reason == old_default_reason:
-            self.reason = new_default_reason
+        # HTTP status codes are mapped to short descriptions in the
+        # httputil.responses dictionary, 200 maps to "OK", 403 maps to
+        # "Forbidden" etc.
+        #
+        # If code is updated and it previously had a reason matching its short
+        # description, we update reason to match the new code's short
+        # description.
+        #
+        if self.reason == httputil.responses.get(change['old'], 'Unknown'):
+            self.reason = httputil.responses.get(change['new'], 'Unknown')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -13,8 +13,20 @@ def translate_ciao(path, host, response, orig_response, port):
     response.headers["Proxied-Path"] = path
     response.body = response.body.replace(b"ciao", b"hello")
 
-def hello_to_foo(path, host, response, port):
+def hello_to_foo(response):
     response.body = response.body.replace(b"hello", b"foo")
+
+# Example from the rewrite_response docstring
+def dog_to_cat(response):
+    response.headers["I-Like"] = "tacos"
+    response.body = response.body.replace(b'dog', b'cat')
+
+
+# Example from the rewrite_response docstring
+def cats_only(response, path):
+    if path.startswith("/cat-club"):
+        response.code = 403
+        response.body = b"dogs not allowed"
 
 c.ServerProxy.servers = {
     'python-http': {
@@ -61,6 +73,14 @@ c.ServerProxy.servers = {
     'python-chained-rewrite-response': {
         'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
         'rewrite_response': [translate_ciao, hello_to_foo],
+    },
+    'python-cats-only-rewrite-response': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'rewrite_response': [dog_to_cat, cats_only],
+    },
+    'python-dogs-only-rewrite-response': {
+        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'rewrite_response': [cats_only, dog_to_cat],
     },
 }
 

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -105,6 +105,21 @@ def test_chained_rewrite_response():
     assert s.startswith('GET /foo-a-tutti?token=')
 
 
+def test_cats_and_dogs_rewrite_response():
+    r = request_get(PORT, '/python-cats-only-rewrite-response/goats', TOKEN)
+    assert r.code == 200
+    r = request_get(PORT, '/python-cats-only-rewrite-response/cat-club', TOKEN)
+    s = r.read().decode('ascii')
+    assert r.code == 403
+    assert r.reason == "Forbidden"
+    assert s == "dogs not allowed"
+    r = request_get(PORT, '/python-dogs-only-rewrite-response/cat-club', TOKEN)
+    s = r.read().decode('ascii')
+    assert r.code == 403
+    assert r.reason == "Forbidden"
+    assert s == "cats not allowed"
+
+
 def test_server_proxy_non_absolute():
     r = request_get(PORT, '/python-http/abc', TOKEN)
     assert r.code == 200


### PR DESCRIPTION
I noticed an annoying discrepancy between Tornado's `HTTPResponse` and my `RewritableResponse` when changing the HTTP code. In Tornado, the `.reason` attribute defaults to the text corresponding to the `.code` attribute. However, in `RewritableResponse`, we expect the `.code` attribute to be changed. If you change `.code`, then `.reason` retains the text generated for the previous code. In this PR, I add an observer which updates the `.reason` attribute if `.code` has changed and `.reason` still has its default value.

I also extended the documentation to illustrate more of the functionality provided, and extended the tests accordingly.