### PR TITLE
Remove empty JupyterLab style

### DIFF
--- a/jupyterlab-server-proxy/src/index.ts
+++ b/jupyterlab-server-proxy/src/index.ts
@@ -3,8 +3,6 @@ import { ILauncher } from '@jupyterlab/launcher';
 import { PageConfig } from '@jupyterlab/coreutils';
 import { IFrame, MainAreaWidget, WidgetTracker } from '@jupyterlab/apputils';
 
-import '../style/index.css';
-
 function newServerProxyWidget(id: string, url: string, text: string): MainAreaWidget<IFrame> {
   const content = new IFrame({
     sandbox: ['allow-same-origin', 'allow-scripts', 'allow-popups', 'allow-forms'],


### PR DESCRIPTION
- fixes #308
- removes empty `index.css` and reference to it in `index.ts`
  - by extension, removes the need to ship `style-loader` and `css-loader` runtimes
  - `third-party-licenses.json` will still be created, but will be empty
