### PR TITLE
Run publish workflow for tags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,6 +25,8 @@ on:
     branches-ignore:
       - "dependabot/**"
       - "pre-commit-ci-update-config"
+    tags:
+      - "*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Specifying branches means tags must also be specified: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore

https://github.com/jupyterhub/jupyter-server-proxy/pull/310