### PR TITLE
Rename jupyterlab extension id to match convention

### DIFF
--- a/jupyterlab-server-proxy/src/index.ts
+++ b/jupyterlab-server-proxy/src/index.ts
@@ -104,7 +104,7 @@ async function activate(app: JupyterFrontEnd, launcher: ILauncher, restorer: ILa
  * Initialization data for the jupyterlab-server-proxy extension.
  */
 const extension: JupyterFrontEndPlugin<void> = {
-  id: 'jupyterlab-server-proxy',
+  id: '@jupyterlab/server-proxy:plugin',
   autoStart: true,
   requires: [ILauncher, ILayoutRestorer],
   activate: activate


### PR DESCRIPTION
Allow disabling the extension using the name reported for the plugin by jupyter labextension CLI tools.

More details in issue #322 