### PR TITLE
[bugfix] Hop by hop header handling

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -280,10 +280,20 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
                        "See https://jupyter-server-proxy.readthedocs.io/en/latest/arbitrary-ports-hosts.html for info.".format(host=host))
             return
 
-        if 'Proxy-Connection' in self.request.headers:
-            del self.request.headers['Proxy-Connection']
-        if 'Transfer-Encoding' in self.request.headers:
-            del self.request.headers['Transfer-Encoding']
+        hop_by_hop_headers = [
+            'Proxy-Connection',
+            'Keep-Alive',
+            'Transfer-Encoding',
+            'TE',
+            'Connection',
+            'Trailer',
+            'Upgrade',
+            'Proxy-Authorization',
+            'Proxy-Authenticate'
+        ]
+        for header_to_remove in hop_by_hop_headers:
+            if header_to_remove in self.request.headers:
+                del self.request.headers[header_to_remove]
 
         self._record_activity()
 

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -280,6 +280,9 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
                        "See https://jupyter-server-proxy.readthedocs.io/en/latest/arbitrary-ports-hosts.html for info.".format(host=host))
             return
 
+        # Remove hop-by-hop headers that don't necessarily apply to the request we are making
+        # to the backend. See https://github.com/jupyterhub/jupyter-server-proxy/pull/328
+        # for more information
         hop_by_hop_headers = [
             'Proxy-Connection',
             'Keep-Alive',

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -282,6 +282,8 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
 
         if 'Proxy-Connection' in self.request.headers:
             del self.request.headers['Proxy-Connection']
+        if 'Transfer-Encoding' in self.request.headers:
+            del self.request.headers['Transfer-Encoding']
 
         self._record_activity()
 


### PR DESCRIPTION
In SageMaker Notebook several ML tools do not work, including `aim`, `lit`, `mlflow`, `streamlit`, etc. 
The reason: `jupyter-server-proxy` fails on POST requests if the client sends the body using `Transfer-Encoding: chunked`.

`TensorBoard` does work only because of a workaround solution of replacing all the `POST` requests with `GET`s.

**In more detail:**
The `Transfer-Encoding` is used by http client to specify whether the `POST` method streams without need of knowing content length ahead of time.

Client request path is roughly:
```
[1] Client Browser  -> [2] AWS SageMaker Proxy  -> [3] Jupyter Server Proxy a.k.a. nbserverproxy
                                                           |
                                                           v
                                                   [4] Some Server (Aim / MLFlow / Streamlit / Lit / etc)
```

Now, forwarding some headers, including `Transfer-Encoding` is wrong because the transfer encoding between `[2]->[3]` can be different from `[3]->[4]`. In our case, `SageMaker` does always use `Transfer-Encoding: chunked` for `POST` requests which makes it to override `Transfer-Encoding` header value of request `[3]->[4]` while the http client used by `[3]` does not have to change the actual transfer encoding accordingly (it simply overrides headers).
When receiving `POST` request body by `[4]` it fails to decode the data because although the header specifies chunked , the body is encoded as a whole, not in chunks (by using `Content-Length` to detect end of message instead of `\r\n` sentinels) .
The `HTTP` standard defines https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding as `Hop-By-Hop header` (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) thus must not be retransmitted by proxies or cached. In other http proxy implementations such as `squid`, `node-http-proxy`,  etc. such headers are removed prior to sending to endpoint.

**This PR focuses on removing not only `Transfer-Encoding` but all hop-by-hop headers to avoid such conflicts.**

Note: SageMaker does not come with the latest `jupyter-server-proxy`. But the issue persists even after upgrading.

**References:**
- aimhubio/aim#1336
- aws/amazon-sagemaker-examples#1595
- plotly/jupyter-dash#39
- awslabs/sagemaker-explaining-credit-decisions#6
- mlflow/mlflow#1120
- PAIR-code/lit#41

- https://github.com/tensorflow/tensorboard/blob/master/tensorboard/webapp/webapp_data_source/tb_http_client.ts#L97-L100