### PR TITLE
Support proxying to a server process via a Unix socket

### DIFF
--- a/docs/source/server-process.rst
+++ b/docs/source/server-process.rst
@@ -18,6 +18,8 @@ Server Process options
 Server Processes are configured with a dictionary of key value
 pairs.
 
+.. _server-process-cmd:
+
 ``command``
 ^^^^^^^^^^^
 
@@ -26,7 +28,8 @@ pairs.
    * A list of strings that is the command used to start the
      process. The following template strings will be replaced:
 
-     * ``{port}`` the port the process should listen on.
+     * ``{port}`` the port (or path if :ref:`server-process-unix-socket` is True)
+       that the process should listen on.
 
      * ``{base_url}`` the base URL of the notebook
 
@@ -94,6 +97,23 @@ pairs.
 
      Set the port that the service will listen on. The default is to
      automatically select an unused port.
+
+.. _server-process-unix-socket:
+
+``unix_socket``
+^^^^^^^^^^^^^^^
+
+    If *True*, the server will listen on a Unix socket at a filesystem path, instead
+    of a TCP port. The ``{port}`` argument (see :ref:`server-process-cmd`) will be a
+    filesystem path for this socket instead of a port number. The server should
+    create a Unix socket bound to this path and listen for HTTP requests on it.
+
+    The Unix socket will only be available to the user the server belongs to,
+    whereas TCP sockets are available to any users on the same host.
+
+    If this is used, the ``port`` configuration key is ignored.
+
+    Defaults to *False*.
 
 
 ``mappath``

--- a/docs/source/server-process.rst
+++ b/docs/source/server-process.rst
@@ -60,8 +60,8 @@ pairs.
 
    * A dictionary of strings that are passed in as the environment to
      the started process, in addition to the environment of the notebook
-     process itself. The strings ``{port}`` and ``{base_url}`` will be
-     replaced as for **command**.
+     process itself. The strings ``{port}``, ``{unix_socket}`` and
+     ``{base_url}`` will be replaced as for **command**.
 
    * A callable that takes any :ref:`callable arguments <server-process/callable-arguments>`,
      and returns a dictionary of strings that are used & treated same as above.
@@ -111,11 +111,14 @@ pairs.
     Jupyter Server Proxy to create a temporary directory to hold the socket,
     ensuring that only the user running Jupyter can connect to it.
 
-    If this is used, the ``{port}`` argument in the command template
-    (see :ref:`server-process-cmd`) will be a filesystem path for this socket
-    instead of a port number. The server should create a Unix socket bound to
-    this path and listen for HTTP requests on it. The ``port`` configuration key
-    will be ignored.
+    If this is used, the ``{unix_socket}`` argument in the command template
+    (see :ref:`server-process-cmd`) will be a filesystem path. The server should
+    create a Unix socket bound to this path and listen for HTTP requests on it.
+    The ``port`` configuration key will be ignored.
+
+    .. note::
+
+       Proxying websockets over a Unix socket requires Tornado >= 6.3.
 
 
 ``mappath``

--- a/docs/source/server-process.rst
+++ b/docs/source/server-process.rst
@@ -103,15 +103,16 @@ pairs.
 ``unix_socket``
 ^^^^^^^^^^^^^^^
 
-    If *True*, the server will listen on a Unix socket at a filesystem path, instead
-    of a TCP port. The ``{port}`` argument (see :ref:`server-process-cmd`) will be a
-    filesystem path for this socket instead of a port number. The server should
-    create a Unix socket bound to this path and listen for HTTP requests on it.
+    This option uses a Unix socket on a filesystem path, instead of a TCP
+    port. It can be passed as a string specifying the socket path, or *True* for
+    Jupyter Server Proxy to create a temporary directory to hold the socket,
+    ensuring that only the user running Jupyter can connect to it.
 
-    The Unix socket will only be available to the user the server belongs to,
-    whereas TCP sockets are available to any users on the same host.
-
-    If this is used, the ``port`` configuration key is ignored.
+    If this is used, the ``{port}`` argument in the command template
+    (see :ref:`server-process-cmd`) will be a filesystem path for this socket
+    instead of a port number. The server should create a Unix socket bound to
+    this path and listen for HTTP requests on it. The ``port`` configuration key
+    will be ignored.
 
     Defaults to *False*.
 

--- a/docs/source/server-process.rst
+++ b/docs/source/server-process.rst
@@ -114,8 +114,6 @@ pairs.
     this path and listen for HTTP requests on it. The ``port`` configuration key
     will be ignored.
 
-    Defaults to *False*.
-
 
 ``mappath``
 ^^^^^^^^^^^

--- a/docs/source/server-process.rst
+++ b/docs/source/server-process.rst
@@ -28,8 +28,11 @@ pairs.
    * A list of strings that is the command used to start the
      process. The following template strings will be replaced:
 
-     * ``{port}`` the port (or path if :ref:`server-process-unix-socket` is True)
-       that the process should listen on.
+     * ``{port}`` the port that the process should listen on. This will be 0 if
+       it should use a Unix socket instead.
+
+     * ``{unix_socket}`` the path at which the process should listen on a Unix
+       socket. This will be an empty string if it should use a TCP port.
 
      * ``{base_url}`` the base URL of the notebook
 

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     from .utils import Callable
 
-def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port, mappath, request_headers_override, rewrite_response):
+def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port, unix, mappath, request_headers_override, rewrite_response):
     """
     Create a SuperviseAndProxyHandler subclass with given parameters
     """
@@ -30,6 +30,7 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url,
             self.proxy_base = name
             self.absolute_url = absolute_url
             self.requested_port = port
+            self.unix_sock = unix
             self.mappath = mappath
             self.rewrite_response = rewrite_response
 
@@ -100,6 +101,7 @@ def make_handlers(base_url, server_processes):
             sp.timeout,
             sp.absolute_url,
             sp.port,
+            sp.unix,
             sp.mappath,
             sp.request_headers_override,
             sp.rewrite_response,
@@ -114,7 +116,7 @@ def make_handlers(base_url, server_processes):
 
 LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title', 'path_info'])
 ServerProcess = namedtuple('ServerProcess', [
-    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port',
+    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'unix',
     'mappath', 'launcher_entry', 'new_browser_tab', 'request_headers_override', 'rewrite_response',
 ])
 
@@ -127,6 +129,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
         timeout=server_process_config.get('timeout', 5),
         absolute_url=server_process_config.get('absolute_url', False),
         port=server_process_config.get('port', 0),
+        unix=server_process_config.get('unix', False),
         mappath=server_process_config.get('mappath', {}),
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -146,8 +146,9 @@ class ServerProxy(Configurable):
         Value should be a dictionary with the following keys:
           command
             An optional list of strings that should be the full command to be executed.
-            The optional template arguments {{port}} and {{base_url}} will be substituted with the
-            port the process should listen on and the base-url of the notebook.
+            The optional template arguments {{port}}, {{unix_socket}} and {{base_url}}
+            will be substituted with the port or Unix socket path the process should
+            listen on and the base-url of the notebook.
 
             Could also be a callable. It should return a list.
 
@@ -157,7 +158,7 @@ class ServerProxy(Configurable):
 
           environment
             A dictionary of environment variable mappings. As with the command
-            traitlet, {{port}} and {{base_url}} will be substituted.
+            traitlet, {{port}}, {{unix_socket}} and {{base_url}} will be substituted.
 
             Could also be a callable. It should return a dictionary.
 
@@ -170,6 +171,13 @@ class ServerProxy(Configurable):
 
           port
             Set the port that the service will listen on. The default is to automatically select an unused port.
+
+          unix_socket
+            If set, the service will listen on a Unix socket instead of a TCP port.
+            Set to True to use a socket in a new temporary folder, or a string
+            path to a socket. This overrides port.
+
+            Proxying websockets over a Unix socket requires Tornado >= 6.3.
 
           mappath
             Map request paths to proxied paths.
@@ -202,7 +210,7 @@ class ServerProxy(Configurable):
 
           request_headers_override
             A dictionary of additional HTTP headers for the proxy request. As with
-            the command traitlet, {{port}} and {{base_url}} will be substituted.
+            the command traitlet, {{port}}, {{unix_socket}} and {{base_url}} will be substituted.
 
           rewrite_response
             An optional function to rewrite the response for the given service.

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -118,7 +118,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
         timeout=server_process_config.get('timeout', 5),
         absolute_url=server_process_config.get('absolute_url', False),
         port=server_process_config.get('port', 0),
-        unix_socket=server_process_config.get('unix_socket', False),
+        unix_socket=server_process_config.get('unix_socket', None),
         mappath=server_process_config.get('mappath', {}),
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     from .utils import Callable
 
-def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port, unix, mappath, request_headers_override, rewrite_response):
+def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port, unix_socket, mappath, request_headers_override, rewrite_response):
     """
     Create a SuperviseAndProxyHandler subclass with given parameters
     """
@@ -30,7 +30,7 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url,
             self.proxy_base = name
             self.absolute_url = absolute_url
             self.requested_port = port
-            self.unix_sock = unix
+            self.unix_sock = unix_socket
             self.mappath = mappath
             self.rewrite_response = rewrite_response
 
@@ -101,7 +101,7 @@ def make_handlers(base_url, server_processes):
             sp.timeout,
             sp.absolute_url,
             sp.port,
-            sp.unix,
+            sp.unix_socket,
             sp.mappath,
             sp.request_headers_override,
             sp.rewrite_response,
@@ -116,7 +116,7 @@ def make_handlers(base_url, server_processes):
 
 LauncherEntry = namedtuple('LauncherEntry', ['enabled', 'icon_path', 'title', 'path_info'])
 ServerProcess = namedtuple('ServerProcess', [
-    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'unix',
+    'name', 'command', 'environment', 'timeout', 'absolute_url', 'port', 'unix_socket',
     'mappath', 'launcher_entry', 'new_browser_tab', 'request_headers_override', 'rewrite_response',
 ])
 
@@ -129,7 +129,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
         timeout=server_process_config.get('timeout', 5),
         absolute_url=server_process_config.get('absolute_url', False),
         port=server_process_config.get('port', 0),
-        unix=server_process_config.get('unix', False),
+        unix_socket=server_process_config.get('unix_socket', False),
         mappath=server_process_config.get('mappath', {}),
         launcher_entry=LauncherEntry(
             enabled=le.get('enabled', True),

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -30,7 +30,7 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url,
             self.proxy_base = name
             self.absolute_url = absolute_url
             self.requested_port = port
-            self.unix_sock = unix_socket
+            self.unix_socket = unix_socket
             self.mappath = mappath
             self.rewrite_response = rewrite_response
 

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -271,7 +271,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
     @staticmethod
     def is_unix_sock(port):
         """Distinguish Unix socket path from numeric TCP port"""
-        return isinstance(port, (str, bytes)) and port.isdigit()
+        return isinstance(port, (str, bytes)) and not port.isdigit()
 
     @web.authenticated
     async def proxy(self, host, port, proxied_path):

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -316,7 +316,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             else:
                 body = None
 
-        if isinstance(port, (str, bytes)):
+        if isinstance(port, (str, bytes)) and not port.isdigit():
             # Port points to a Unix domain socket
             self.log.debug("Making client for Unix socket %r", port)
             assert host == 'localhost', "Unix sockets only possible on localhost"

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -14,6 +14,7 @@ from copy import copy
 from tempfile import mkdtemp
 
 from tornado import gen, web, httpclient, httputil, process, websocket, ioloop, version_info
+from tornado.simple_httpclient import SimpleAsyncHTTPClient
 
 from jupyter_server.utils import ensure_async, url_path_join
 from jupyter_server.base.handlers import JupyterHandler, utcnow
@@ -317,8 +318,9 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
 
         if isinstance(port, (str, bytes)):
             # Port points to a Unix domain socket
+            self.log.debug("Making client for Unix socket %r", port)
             assert host == 'localhost', "Unix sockets only possible on localhost"
-            client = httpclient.AsyncHTTPClient(resolver=UnixResolver(port))
+            client = SimpleAsyncHTTPClient(resolver=UnixResolver(port))
         else:
             client = httpclient.AsyncHTTPClient()
 

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -587,10 +587,13 @@ class RemoteProxyHandler(ProxyHandler):
 
 
 class NamedLocalProxyHandler(LocalProxyHandler):
-    """Maps a configured name to a local port or Unix socket path
+    """
+    A tornado request handler that proxies HTTP and websockets from a port on
+    the local system. The port is specified in config, and associated with a
+    name which forms part of the URL.
 
     Config will create a subclass of this for each named proxy. A further
-    subclass below is used for named proxies where we also start
+    subclass below is used for named proxies where we also start the server.
     """
     port = 0
     mappath = {}
@@ -664,7 +667,13 @@ class NamedLocalProxyHandler(LocalProxyHandler):
 
 # FIXME: Move this to its own file. Too many packages now import this from nbrserverproxy.handlers
 class SuperviseAndProxyHandler(NamedLocalProxyHandler):
-    '''Manage a given process and requests to it '''
+    """
+    A tornado request handler that proxies HTTP and websockets from a local
+    process which is launched on demand to handle requests. The command and
+    other process options are specified in config.
+
+    A subclass of this will be made for each configured server process.
+    """
 
     def __init__(self, *args, **kwargs):
         self.requested_port = 0

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -645,7 +645,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
         return 5
 
     async def _http_ready_func(self, p):
-        if self.is_unix_sock(p):
+        if self.is_unix_sock(self.port):
             url = 'http://localhost'
             connector = aiohttp.UnixConnector(self.port)
         else:

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -692,6 +692,10 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
                     del self.state['proc']
                     raise
 
+    def get_client_uri(self, protocol, host, port, proxied_path):
+        if isinstance(port, (str, bytes)):
+            port = 0   # Unix socket - port won't be used
+        return super().get_client_uri(protocol, host, port, proxied_path)
 
     @web.authenticated
     async def proxy(self, port, path):

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -326,12 +326,10 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             self.log.debug("Making client for Unix socket %r", port)
             assert host == 'localhost', "Unix sockets only possible on localhost"
             client = SimpleAsyncHTTPClient(resolver=UnixResolver(port))
-            # Use a phony numeric port to make a normal URL so the path can be
-            # parsed back out of it. The host & port in the URL aren't used.
-            req = self._build_proxy_request(host, 0, proxied_path, body)
         else:
             client = httpclient.AsyncHTTPClient()
-            req = self._build_proxy_request(host, port, proxied_path, body)
+
+        req = self._build_proxy_request(host, port, proxied_path, body)
 
         self.log.debug(f"Proxying request to {req.url}")
 
@@ -438,12 +436,10 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             assert host == 'localhost', "Unix sockets only possible on localhost"
             self.log.debug("Opening websocket on Unix socket %r", port)
             resolver = UnixResolver(port)  # Requires tornado >= 6.3
-            # Use a phony numeric port to make a normal URL so the path can be
-            # parsed back out of it. The host & port in the URL aren't used.
-            client_uri = self.get_client_uri('ws', host, 0, proxied_path)
         else:
             resolver = None
-            client_uri = self.get_client_uri('ws', host, port, proxied_path)
+
+        client_uri = self.get_client_uri('ws', host, port, proxied_path)
         headers = self.proxy_request_headers()
 
         def message_cb(message):

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -594,7 +594,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
 
     def __init__(self, *args, **kwargs):
         self.requested_port = 0
-        self.unix_sock = False
+        self.unix_socket = False
         self.mappath = {}
         self.command = list()
         super().__init__(*args, **kwargs)
@@ -613,7 +613,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
         application
         """
         if 'port' not in self.state and self.command:
-            if self.unix_sock:
+            if self.unix_socket:
                 sock_dir = mkdtemp(prefix='jupyter-server-proxy-')
                 self.state['port'] = os.path.join(sock_dir, 'socket')
             else:

--- a/jupyter_server_proxy/unixsock.py
+++ b/jupyter_server_proxy/unixsock.py
@@ -1,0 +1,10 @@
+import socket
+from tornado.netutil import Resolver
+
+
+class UnixResolver(Resolver):
+    def initialize(self, socket_path):
+        self.socket_path = socket_path
+
+    async def resolve(self, host, port, *args, **kwargs):
+        return [(socket.AF_UNIX, self.socket_path)]

--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -31,7 +31,7 @@ class PingableWSClientConnection(websocket.WebSocketClientConnection):
 
 
 def pingable_ws_connect(request=None,on_message_callback=None,
-                        on_ping_callback=None, subprotocols=None):
+                        on_ping_callback=None, subprotocols=None, resolver=None):
     """
     A variation on websocket_connect that returns a PingableWSClientConnection
     with on_ping_callback.
@@ -50,12 +50,18 @@ def pingable_ws_connect(request=None,on_message_callback=None,
             on_message_callback=on_message_callback,
             on_ping_callback=on_ping_callback)
     else:
+        # resolver= parameter requires tornado >= 6.3. Only pass it if needed
+        # (for Unix socket support), so older versions of tornado can still
+        # work otherwise.
+        kwargs = {'resolver': resolver} if resolver else {}
         conn = PingableWSClientConnection(request=request,
             compression_options={},
             on_message_callback=on_message_callback,
             on_ping_callback=on_ping_callback,
             max_message_size=getattr(websocket, '_default_max_message_size', 10 * 1024 * 1024),
-            subprotocols=subprotocols)
+            subprotocols=subprotocols,
+            **kwargs
+        )
 
     return conn.connect_future
 

--- a/tests/resources/httpinfo.py
+++ b/tests/resources/httpinfo.py
@@ -38,7 +38,9 @@ if __name__ == '__main__':
     args = ap.parse_args()
 
     if args.unix_socket:
-        Path(args.unix_socket).unlink(missing_ok=True)
+        unix_socket = Path(args.unix_socket)
+        if unix_socket.exists():
+            unix_socket.unlink()
         httpd = HTTPUnixServer(args.unix_socket, EchoRequestInfo)
     else:
         httpd = HTTPServer(('127.0.0.1', args.port), EchoRequestInfo)

--- a/tests/resources/httpinfo.py
+++ b/tests/resources/httpinfo.py
@@ -1,5 +1,11 @@
+"""
+Simple webserver to respond with an echo of the sent request. It can listen to
+either a tcp port or a unix socket.
+"""
+import argparse
+import socket
+from pathlib import Path
 from http.server import HTTPServer, BaseHTTPRequestHandler
-import sys
 
 class EchoRequestInfo(BaseHTTPRequestHandler):
     def do_GET(self):
@@ -9,9 +15,31 @@ class EchoRequestInfo(BaseHTTPRequestHandler):
         self.wfile.write('{}\n'.format(self.requestline).encode())
         self.wfile.write('{}\n'.format(self.headers).encode())
 
+    def address_string(self):
+        """
+        Overridden to fix logging when serving on Unix socket.
+
+        FIXME: There are still broken pipe messages showing up in the jupyter
+               server logs when running tests with the unix sockets.
+        """
+        if isinstance(self.client_address, str):
+            return self.client_address  # Unix sock
+        return super().address_string()
+
+
+class HTTPUnixServer(HTTPServer):
+    address_family = socket.AF_UNIX
+
 
 if __name__ == '__main__':
-    port = int(sys.argv[1])
-    server_address = ('', port)
-    httpd = HTTPServer(server_address, EchoRequestInfo)
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--port', type=int)
+    ap.add_argument('--unix-socket')
+    args = ap.parse_args()
+
+    if args.unix_socket:
+        Path(args.unix_socket).unlink(missing_ok=True)
+        httpd = HTTPUnixServer(args.unix_socket, EchoRequestInfo)
+    else:
+        httpd = HTTPServer(('127.0.0.1', args.port), EchoRequestInfo)
     httpd.serve_forever()

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -30,24 +30,24 @@ def cats_only(response, path):
 
 c.ServerProxy.servers = {
     'python-http': {
-        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'command': ['python3', './tests/resources/httpinfo.py', '--port={port}'],
     },
     'python-http-abs': {
-        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'command': ['python3', './tests/resources/httpinfo.py', '--port={port}'],
         'absolute_url': True
     },
     'python-http-port54321': {
-        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'command': ['python3', './tests/resources/httpinfo.py', '--port={port}'],
         'port': 54321,
     },
     'python-http-mappath': {
-        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'command': ['python3', './tests/resources/httpinfo.py', '--port={port}'],
         'mappath': {
             '/': '/index.html',
         }
     },
     'python-http-mappathf': {
-        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'command': ['python3', './tests/resources/httpinfo.py', '--port={port}'],
         'mappath': mappathf,
     },
     'python-websocket' : {
@@ -56,8 +56,21 @@ c.ServerProxy.servers = {
             'X-Custom-Header': 'pytest-23456',
         }
     },
+    'python-unix-socket-true' : {
+        'command': ['python3', './tests/resources/httpinfo.py', '--unix-socket={unix_socket}'],
+        'unix_socket': True,
+    },
+    'python-unix-socket-file' : {
+        'command': ['python3', './tests/resources/httpinfo.py', '--unix-socket={unix_socket}'],
+        'unix_socket': "/tmp/jupyter-server-proxy-test-socket",
+    },
+    'python-unix-socket-file-no-command' : {
+        # this server process can be started earlier by first interacting with
+        # python-unix-socket-file
+        'unix_socket': "/tmp/jupyter-server-proxy-test-socket",
+    },
     'python-request-headers': {
-        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'command': ['python3', './tests/resources/httpinfo.py', '--port={port}'],
         'request_headers_override': {
             'X-Custom-Header': 'pytest-23456',
         }
@@ -66,20 +79,20 @@ c.ServerProxy.servers = {
         'command': ['python3', './tests/resources/gzipserver.py', '{port}'],
     },
     'python-http-rewrite-response': {
-        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'command': ['python3', './tests/resources/httpinfo.py', '--port={port}'],
         'rewrite_response': translate_ciao,
         'port': 54323,
     },
     'python-chained-rewrite-response': {
-        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'command': ['python3', './tests/resources/httpinfo.py', '--port={port}'],
         'rewrite_response': [translate_ciao, hello_to_foo],
     },
     'python-cats-only-rewrite-response': {
-        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'command': ['python3', './tests/resources/httpinfo.py', '--port={port}'],
         'rewrite_response': [dog_to_cat, cats_only],
     },
     'python-dogs-only-rewrite-response': {
-        'command': ['python3', './tests/resources/httpinfo.py', '{port}'],
+        'command': ['python3', './tests/resources/httpinfo.py', '--port={port}'],
         'rewrite_response': [cats_only, dog_to_cat],
     },
     'python-proxyto54321-no-command': {

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -22,18 +22,36 @@ def request_get(port, path, token, host='localhost'):
     return h.getresponse()
 
 
-def test_server_proxy_minimal_proxy_path_encoding():
+@pytest.mark.parametrize(
+    'server_process_path',
+    [
+        "/python-http/",
+        "/python-unix-socket-true/",
+        "/python-unix-socket-file/",
+        "/python-unix-socket-file-no-command/",
+    ],
+)
+def test_server_proxy_minimal_proxy_path_encoding(server_process_path):
     """Test that we don't encode anything more than we must to have a valid web
     request."""
     special_path = quote("Hello world 123 åäö 🎉你好世界±¥ :/[]@!$&'()*+,;=-._~?key1=value1", safe=":/?#[]@!$&'()*+,;=-._~")
-    test_url = '/python-http/' + special_path
+    test_url = server_process_path + special_path
     r = request_get(PORT, test_url, TOKEN)
     assert r.code == 200
     s = r.read().decode('ascii')
     assert 'GET /{}&token='.format(special_path) in s
 
 
-def test_server_proxy_hash_sign_encoding():
+@pytest.mark.parametrize(
+    'server_process_path',
+    [
+        "/python-http/",
+        "/python-unix-socket-true/",
+        "/python-unix-socket-file/",
+        "/python-unix-socket-file-no-command/",
+    ],
+)
+def test_server_proxy_hash_sign_encoding(server_process_path):
     """
     FIXME: This is a test to establish the current behavior, but if it should be
            like this is a separate question not yet addressed.
@@ -44,7 +62,7 @@ def test_server_proxy_hash_sign_encoding():
 
     # Case 0: a reference case
     path = "?token={}".format(TOKEN)
-    h.request('GET', '/python-http/' + path)
+    h.request('GET', server_process_path + path)
     r = h.getresponse()
     assert r.code == 200
     s = r.read().decode('ascii')
@@ -52,7 +70,7 @@ def test_server_proxy_hash_sign_encoding():
 
     # Case 1: #bla?token=secret -> everything following # ignored -> redirect because no token
     path = "#bla?token={}".format(TOKEN)
-    h.request('GET', '/python-http/' + path)
+    h.request('GET', server_process_path + path)
     r = h.getresponse()
     assert r.code == 200
     s = r.read().decode('ascii')
@@ -60,7 +78,7 @@ def test_server_proxy_hash_sign_encoding():
 
     # Case 2: %23bla?token=secret -> %23 is # -> everything following # ignored -> redirect because no token
     path = "%23?token={}".format(TOKEN)
-    h.request('GET', '/python-http/' + path)
+    h.request('GET', server_process_path + path)
     r = h.getresponse()
     assert r.code == 200
     s = r.read().decode('ascii')
@@ -79,7 +97,7 @@ def test_server_proxy_hash_sign_encoding():
     #       return await self.proxy(self.port, path)
     #   TypeError: object NoneType can't be used in 'await' expression
     path = "?token={}#test".format(TOKEN)
-    h.request('GET', '/python-http/' + path)
+    h.request('GET', server_process_path + path)
     r = h.getresponse()
     assert r.code == 302
     s = r.read().decode('ascii')


### PR DESCRIPTION
**Updated description**

Unix sockets are an alternative to TCP sockets for local servers: the server listens (and the client connects) on a filesystem path, rather than a numeric port. The big advantage is that, with the right filesystem permissions, the OS can prevent other users (except root) from connecting to a Unix socket, so it's more secure on a multi-user system. See #321 for more details.

This PR adds support for named proxies (those defined in config) to forward to a Unix socket rather than a TCP socket.

- If you set `unix_socket=True` in [server process config](https://jupyter-server-proxy.readthedocs.io/en/latest/server-process.html), JSP will create a temporary directory, and fill the new `{unix_socket}` command template argument with a path inside there, where the server can create a socket. This is equivalent to choosing a random TCP port, and requires that JSP launches the server process itself.
- If you set `unix_socket='/path/to/some.socket'` instead, you are telling JSP that the application will listen at that path. This is equivalent to specifying `port=4321`, and works whether or not JSP launches the process (with or without `command` set).

This works already for regular HTTP requests. Forwarding websockets over a Unix socket will work once Tornado 6.3 is released. If this is a sticking point, we could switch the client code to aiohttp

I have a corresponding branch of my `hello_jupyter_proxy` repo to test this with: https://github.com/takluyver/hello_jupyter_proxy/tree/unix-sock

-----

**Original, outdated description**

This is fairly rough, but if the config for a server process includes `'unix': True` and no port number, j-s-p will create a new temp folder and give the server process a path inside that instead of a TCP port number. It then expects the process to create and bind a Unix socket at the given path, and will connect to that to forward requests.

On a shared host, this means that only the user whose server this is can connect to the socket, whereas anyone with access to the system can connect to a localhost TCP socket. It also avoids the race condition where the parent selects an unused TCP port, but something else binds that port before the child process can.

For now, I've left websockets out of this, because Tornado's websocket client doesn't seem to easily support passing in a resolver object like its HTTPClient does. I think this can be useful even without websocket support, and I'd hope that we could either add to Tornado or find an alternative like aiohttp to fill that in later.


Fixes #321