### PR TITLE
Install `notebook<7` for notebook test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,6 +63,9 @@ jobs:
           pip install jupyter_packaging jupyterlab~=${{ matrix.jupyterlab_version }}.0
           pip install ./dist/jupyter_server_proxy-*.whl
           pip install pytest pytest-cov pytest-html
+          if [ "${{ matrix.jupyter_app }}" == "notebook" ]; then
+            pip install "notebook<7"
+          fi
           pip freeze
 
       - name: Run tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,6 +63,7 @@ jobs:
           pip install jupyter_packaging jupyterlab~=${{ matrix.jupyterlab_version }}.0
           pip install ./dist/jupyter_server_proxy-*.whl
           pip install pytest pytest-cov pytest-html
+          # Ensure we don't accidentally depend on notebook
           if [ "${{ matrix.jupyter_app }}" == "notebook" ]; then
             pip install "notebook<7"
           fi
@@ -110,7 +111,8 @@ jobs:
 
       - name: Install Acceptance test dependencies
         run: |
-          pip install robotframework-jupyterlibrary
+          # the acceptance test requires notebook to run
+          pip install "notebook<7" robotframework-jupyterlibrary
 
       - name: Run acceptance tests
         run: |


### PR DESCRIPTION
nbclassic 0.3.7 (required by jupyterlab) automatically installs notebook, but the recently released 0.4.2 doesn't. I think this is because nbclassic 0.4+ now includes all the frontend content that was previously in the notebook package. Since jupyter-server provides the backend for nbclassic it doesn't require notebook.