### PR TITLE
Fix config filename in config via traitlets doc

### DIFF
--- a/docs/server-process.rst
+++ b/docs/server-process.rst
@@ -216,7 +216,7 @@ mechanism used by Jupyter Notebook. It can take config in Python
 and we can use that to specify Server Processes - including functions
 if we want tighter control over what process is spawned.
 
-#. Create a file called ``jupyter_notebook_config.py`` in one of the
+#. Create a file called ``jupyter_server_config.py`` in one of the
    Jupyter config directories. You can get a list of these directories
    by running ``jupyter --paths`` and looking under the 'config'
    section


### PR DESCRIPTION
The file has to be named `jupyter_server_config.py` when using JupyterLab and version of Notebook >= 6.5. 

This is because jupyter-server is replacing the notebook backend:
https://jupyter-server.readthedocs.io/en/latest/operators/migrate-from-nbserver.html

It might be better to actually explain how the file should be named based on the version used, but I wanted to provide a starting point for the conversation.