### PR TITLE
ci: test against modern python versions and fix broken test suite

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
         jupyterlab_version: [2, 3]
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: ["3.6", "3.11"]
         jupyter_app: [notebook, lab]
 
     steps:

--- a/tests/acceptance/Classic.robot
+++ b/tests/acceptance/Classic.robot
@@ -1,3 +1,7 @@
+*** Comments ***
+To learn more about these .robot files, see
+https://robotframework-jupyterlibrary.readthedocs.io/en/stable/.
+
 *** Settings ***
 Documentation     Server Proxies in Notebook Classic
 Library           JupyterLibrary

--- a/tests/acceptance/Lab.robot
+++ b/tests/acceptance/Lab.robot
@@ -1,3 +1,7 @@
+*** Comments ***
+To learn more about these .robot files, see
+https://robotframework-jupyterlibrary.readthedocs.io/en/stable/.
+
 *** Settings ***
 Documentation     Server Proxies in Lab
 Library           JupyterLibrary

--- a/tests/acceptance/__init__.robot
+++ b/tests/acceptance/__init__.robot
@@ -1,3 +1,7 @@
+*** Comments ***
+To learn more about these .robot files, see
+https://robotframework-jupyterlibrary.readthedocs.io/en/stable/.
+
 *** Settings ***
 Documentation     Acceptance tests for jupyter-server-proxy
 Library           JupyterLibrary

--- a/tests/acceptance/__init__.robot
+++ b/tests/acceptance/__init__.robot
@@ -13,6 +13,9 @@ Suite Teardown    Clean Up
 Set Up
     ${notebook dir} =    Set Variable    ${OUTPUT DIR}${/}notebooks
     Copy Directory    resources    ${notebook dir}
+    Set Environment Variable
+    ...    name=JUPYTER_CONFIG_DIR
+    ...    value=${notebook dir}
     Wait For New Jupyter Server To Be Ready
     ...    stdout=${OUTPUT DIR}${/}server.log
     ...    notebook_dir=${notebook dir}

--- a/tests/acceptance/test_acceptance.py
+++ b/tests/acceptance/test_acceptance.py
@@ -15,7 +15,7 @@ def test_robot():
         shutil.rmtree(OUTPUT)
 
     return_code = subprocess.call(
-        [*map(str, ["robot", "--outputdir", OUTPUT, HERE])],
+        ["robot", "--consolecolors=on", f"--outputdir={OUTPUT}", str(HERE)],
         cwd=str(HERE)
     )
 


### PR DESCRIPTION
I figure the most important versions to test are the oldest and newest. But,  it can help to know if something is just too old or just too new to function as well.

With this PR I update the CI system to run against py36, 37, 310, and 311, instead of py36, 37, 38, 39.