### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         # specified below, these parameters have no meaning on their own and
         # gain meaning on how job steps use them.
         jupyterlab_version: [2, 3]
-        python: ["3.6", "3.11"]
+        python: ["3.7", "3.11"]
         jupyter_app: [notebook, lab]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup_args = dict(
     },
     zip_safe=False,
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     keywords=["Jupyter", "JupyterLab", "JupyterLab3"],
     classifiers=[
         "Framework :: Jupyter",
@@ -115,10 +115,11 @@ setup_args = dict(
         "Operating System :: MacOS :: MacOS X",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Framework :: Jupyter",
     ],
     data_files=[


### PR DESCRIPTION
For reference jupyterhub/jupyterhub has also dropped support for Python 3.6, and it has reached end of life 10 months ago. Requiring Python 3.7+ for the next release of this software seems very reasonable.