### PR TITLE
ci: use ubuntu-22.04, firefox and geckodriver now available

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,11 +27,12 @@ on:
 
 jobs:
   test:
-    # FIXME: We need ubutnu-20.04 until firefox and geckowebdriver is available
-    #        in ubuntu-22.04. To check if we can upgrade to ubuntu-22.04, see
-    #        https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#browsers-and-drivers
+    # NOTE: The worker environment running this job needs firefox and
+    #       geckowebdriver available. Before upgrading to ubuntu-24.04 in the
+    #       future, check and see its available in a location like this:
+    #       https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#browsers-and-drivers
     #
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
As seen [here](https://github.com/actions/runner-images/blame/e9b59a540ed5e360dbdbc018830daa828f9ec067/images/linux/Ubuntu2204-Readme.md?plain=1#L164-L180), firefox and geckodriver as needed by browser simulation tests in our CI system is now available in the ubuntu-22.04 environment. So, due to that we upgrade to use it.