### PR TITLE
maint, breaking: drop support for jupyterlab 2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.11"]
         jupyter_server-version: ["1", "2"]
-        jupyterlab-version: ["2", "3"]
+        jupyterlab-version: ["3"]
 
     steps:
       - uses: actions/checkout@v3
@@ -109,20 +109,7 @@ jobs:
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -iE "jupyter_server_proxy.*OK" -
 
-      - name: Install JupyterLab Extension
-        if: matrix.jupyterlab-version == '2'
-        run: |
-          export NODE_OPTIONS=--openssl-legacy-provider
-          cd labextension
-          jupyter labextension install . --no-build --debug
-          jupyter lab build --minimize=False --debug
-
       - name: Check the lab extension
-        # We test the labextension thoroughly in the acceptance tests below, so
-        # we have conditionally disabled this basic check is to avoid issues in
-        # jupyterlab.browser_check with jupyterlab 2 and jupyter_server 2+.
-        #
-        if: ${{ !(matrix.jupyterlab-version == '2' && matrix.jupyter_server-version != '1') }}
         run: |
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -iE '@jupyterhub/jupyter-server-proxy.*OK.*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ git clone https://github.com/jupyterhub/jupyter-server-proxy.git
 cd jupyter-server-proxy
 # Install package in development mode
 pip install -e ".[test]"
-# Link your development version of the extension with JupyterLab (only for JupyterLab 3)
+# Link your development version of the extension with JupyterLab
 jupyter labextension develop --overwrite .
 # Server extension must be manually installed in develop mode
 jupyter server extension enable jupyter_server_proxy

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Server via the container.
 
 ### Requirements
 
-- `jupyterlab>=2` or `notebook`
+Either `jupyterlab>=3` or `notebook<7` is required.
 
 ### Python package
 
@@ -70,22 +70,14 @@ pip install jupyter-server-proxy
 conda install jupyter-server-proxy -c conda-forge
 ```
 
-#### Local development
-
-> See the [contributing guide](https://github.com/jupyterhub/jupyter-server-proxy/blob/main/CONTRIBUTING.md).
-
 ### JupyterLab extension
 
-Note that as the JupyterLab extension only is a graphical interface to
-launch registered applications in the python package, the extension
-requires the python package to be installed.
+A JupyterLab extension is bundled with the Python package to provide launch
+buttons in JupyterLab's Launcher panel for registered server processes.
 
-As of version 3.0.0 the Python package ships with a JupyterLab 3 compatible
-extension, making this step only needed for JupyterLab 2.
+![](docs/source/_static/images/labextension-launcher.png)
 
-```bash
-jupyter labextension install @jupyterhub/jupyter-server-proxy
-```
+Clicking on them opens the proxied application in a new browser window.
 
 ## Disable
 
@@ -107,3 +99,7 @@ jupyter nbextension disable --sys-prefix --py jupyter_server_proxy
 ```bash
 jupyter labextension disable @jupyterhub/jupyter-server-proxy
 ```
+
+#### Local development
+
+To setup a local development environment, see the [contributing guide](https://github.com/jupyterhub/jupyter-server-proxy/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Server via the container.
 
 ### Requirements
 
-Either `jupyterlab>=3` or `notebook<7` is required.
+Either `jupyterlab>=3` or `notebook` is required.
 
 ### Python package
 

--- a/docs/source/launchers.md
+++ b/docs/source/launchers.md
@@ -17,20 +17,13 @@ is already running, it is reused.
 
 ```
 
-## JupyterLab Launcher Extension
+## JupyterLab Extension
 
-The @jupyterhub/jupyter-server-proxy JupyterLab extension can be installed to
-provide launcher icons for registered server processes.
-
-```bash
-jupyter labextension install @jupyterhub/jupyter-server-proxy
-```
-
-This should provide icons for each registered process in the main
-JupyterLab launcher
+A JupyterLab extension is bundled with the Python package to provide launch
+buttons in JupyterLab's Launcher panel for registered server processes.
 
 ```{image} _static/images/labextension-launcher.png
 
 ```
 
-Clicking on them will open the application in a new window.
+Clicking on them opens the proxied application in a new browser window.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ requires-python = ">=3.8"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
-    "Framework :: Jupyter :: JupyterLab :: 2",
     "Framework :: Jupyter :: JupyterLab :: 3",
     "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
     "Framework :: Jupyter :: JupyterLab :: Extensions",


### PR DESCRIPTION
This PR is based on top of #393 as I'm modifying the docs also modified there. This PR includes only one commit, [369e5b](https://github.com/jupyterhub/jupyter-server-proxy/pull/394/commits/b369e5bb54105372ded580e84afddc2b7a4e831b).

With this PR, the JupyterLab extension will still be published as an NPM package to @jupyterhub/jupyter-server-proxy, but we will not test against it or ensure future functioning, or document how to install it etc. Dropping support for jupyterlab 2 was proposed to go with the 4.0.0 release planned in(#388 as jupyterlab 4 is coming out and we are to support both jupyterlab 3 and 4 already.