### PR TITLE
Use `pytest.fixture`s for starting servers, use `importlib*metadata`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
         # NOTE: See CONTRIBUTING.md for a local development setup that differs
         #       slightly from this.
         #
-        #       Pytest options are set in tests/pytest.ini.
+        #       Pytest options are set in `pyproject.toml`.
         run: |
           pip install -vv $(ls ./dist/jupyter_server_proxy-*.whl)\[acceptance\] 'jupyterlab~=${{ matrix.jupyterlab-version }}.0' 'jupyter_server~=${{ matrix.jupyter_server-version }}.0'
 
@@ -76,18 +76,8 @@ jobs:
           pip freeze
           pip check
 
-      - name: Run tests against jupyter-notebook
+      - name: Run tests
         run: |
-          JUPYTER_TOKEN=secret jupyter-notebook --config=./tests/resources/jupyter_server_config.py &
-          sleep 5
-          cd tests
-          pytest -k "not acceptance"
-
-      - name: Run tests against jupyter-lab
-        run: |
-          JUPYTER_TOKEN=secret jupyter-lab --config=./tests/resources/jupyter_server_config.py &
-          sleep 5
-          cd tests
           pytest -k "not acceptance"
 
       - name: Upload pytest and coverage reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,16 +22,10 @@ jupyter labextension develop --overwrite .
 jupyter server extension enable jupyter_server_proxy
 ```
 
-Before running tests, you need a server that we can test against.
-
-```bash
-JUPYTER_TOKEN=secret jupyter-lab --config=./tests/resources/jupyter_server_config.py --no-browser
-```
-
 Run the tests:
 
 ```bash
-pytest --verbose
+pytest
 ```
 
 These generate test and coverage reports in `build/pytest` and `build/coverage`.

--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -71,6 +71,11 @@ def _load_jupyter_server_extension(nbapp):
         ],
     )
 
+    nbapp.log.debug(
+        "[jupyter-server-proxy] Started with known servers: %s",
+        ", ".join([p.name for p in server_processes]),
+    )
+
 
 # For backward compatibility
 load_jupyter_server_extension = _load_jupyter_server_extension

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -4,7 +4,13 @@ Traitlets based configuration for jupyter_server_proxy
 from collections import namedtuple
 from warnings import warn
 
-import pkg_resources
+import sys
+
+if sys.version_info < (3, 10):  # pragma: no cover
+    from importlib_metadata import entry_points
+else:  # pragma: no cover
+    from importlib.metadata import entry_points
+
 from jupyter_server.utils import url_path_join as ujoin
 from traitlets import Dict, List, Tuple, Union, default, observe
 from traitlets.config import Configurable
@@ -90,7 +96,7 @@ def _make_supervisedproxy_handler(sp: ServerProcess):
 
 def get_entrypoint_server_processes(serverproxy_config):
     sps = []
-    for entry_point in pkg_resources.iter_entry_points("jupyter_serverproxy_servers"):
+    for entry_point in entry_points(group="jupyter_serverproxy_servers"):
         name = entry_point.name
         server_process_config = entry_point.load()()
         sps.append(make_server_process(name, server_process_config, serverproxy_config))

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -1,10 +1,9 @@
 """
 Traitlets based configuration for jupyter_server_proxy
 """
+import sys
 from collections import namedtuple
 from warnings import warn
-
-import sys
 
 if sys.version_info < (3, 10):  # pragma: no cover
     from importlib_metadata import entry_points

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp",
+    "importlib_metadata >=4.8.3 ; python_version<\"3.10\"",
     "jupyter-server >=1.0",
     "simpervisor >=0.4",
 ]
@@ -175,3 +176,26 @@ tag_template = "v{new_version}"
 
 [[tool.tbump.file]]
 src = "labextension/package.json"
+
+[tool.pytest.ini_options]
+cache_dir = "build/.cache/pytest"
+addopts = [
+    "-vv",
+    "--cov=jupyter_server_proxy",
+    "--cov-branch",
+    "--cov-context=test",
+    "--cov-report=term-missing:skip-covered",
+    "--cov-report=html:build/coverage",
+    "--html=build/pytest/index.html",
+    "--color=yes",
+]
+
+[tool.coverage.run]
+data_file = "build/.coverage"
+concurrency = [
+    "multiprocessing",
+    "thread"
+]
+
+[tool.coverage.html]
+show_contexts = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,111 @@
+"""Reusable test fixtures for ``jupyter_server_proxy``."""
+import socket
+import sys
+import os
+from pytest import fixture
+from subprocess import Popen
+from typing import Generator, Any, Tuple
+from pathlib import Path
+from uuid import uuid4
+from urllib.error import URLError
+import time
+from urllib.request import urlopen
+import shutil
+
+HERE = Path(__file__).parent
+RESOURCES = HERE / "resources"
+
+@fixture
+def a_token() -> str:
+    """Get a random UUID to use for a token."""
+    return str(uuid4())
+
+
+@fixture
+def an_unused_port() -> int:
+    """Get a random unused port."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    s.listen(1)
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@fixture(params=["notebook", "lab"])
+def a_server_cmd(request: Any) -> str:
+    """Get a viable name for a command."""
+    return request.param
+
+
+@fixture
+def a_server(
+    a_server_cmd: str,
+    tmp_path: Path,
+    an_unused_port: int,
+    a_token: str,
+) -> Generator[str, None, None]:
+    """Get a running server."""
+    # get a copy of the resources
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    shutil.copytree(RESOURCES, tests / "resources")
+    args = [
+        sys.executable,
+        "-m",
+        "jupyter",
+        a_server_cmd,
+        f"--port={an_unused_port}",
+        "--no-browser",
+        "--config=./tests/resources/jupyter_server_config.py",
+        "--debug",
+    ]
+
+    # prepare an env
+    env = dict(os.environ)
+    env.update(JUPYTER_TOKEN=a_token)
+
+    # start the process
+    server_proc = Popen(args, cwd=str(tmp_path), env=env)
+
+    # prepare some URLss
+    url = f"http://127.0.0.1:{an_unused_port}/"
+    canary_url = f"{url}favicon.ico"
+    shutdown_url = f"{url}api/shutdown?token={a_token}"
+
+    retries = 10
+
+    while retries:
+        try:
+            urlopen(canary_url)
+            break
+        except URLError as err:
+            if "Connection refused" in str(err):
+                print(
+                    f"{a_server_cmd} not ready, will try again in 0.5s [{retries} retries]",
+                    flush=True,
+                )
+                time.sleep(0.5)
+                retries -= 1
+                continue
+            raise err
+
+    print(f"{a_server_cmd} is ready...", flush=True)
+
+    yield url
+
+    # clean up after server is no longer needed
+    print(f"{a_server_cmd} shutting down...", flush=True)
+    urlopen(shutdown_url, data=[])
+    server_proc.wait()
+    print(f"{a_server_cmd} is stopped", flush=True)
+
+
+@fixture
+def a_server_port_and_token(
+    a_server: str,  # noqa
+    an_unused_port: int,
+    a_token: str,
+) -> Tuple[int, str]:
+    """Get the port and token for a running server."""
+    return an_unused_port, a_token

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,21 @@
 """Reusable test fixtures for ``jupyter_server_proxy``."""
+import os
+import shutil
 import socket
 import sys
-import os
-from pytest import fixture
-from subprocess import Popen
-from typing import Generator, Any, Tuple
-from pathlib import Path
-from uuid import uuid4
-from urllib.error import URLError
 import time
+from pathlib import Path
+from subprocess import Popen
+from typing import Any, Generator, Tuple
+from urllib.error import URLError
 from urllib.request import urlopen
-import shutil
+from uuid import uuid4
+
+from pytest import fixture
 
 HERE = Path(__file__).parent
 RESOURCES = HERE / "resources"
+
 
 @fixture
 def a_token() -> str:

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,9 +1,0 @@
-[pytest]
-addopts =
-    -s
-    -vv
-    --cov jupyter_server_proxy
-    --cov-report term-missing:skip-covered
-    --cov-report html:../build/coverage
-    --html=../build/pytest/index.html
-    --color=yes

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 HERE = Path(__file__).parent.resolve()
 

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -1,3 +1,10 @@
+from pathlib import Path
+import sys
+
+HERE = Path(__file__).parent.resolve()
+
+sys.path.append(str(HERE))
+
 # load the config object for traitlets based configuration
 c = get_config()  # noqa
 
@@ -116,9 +123,5 @@ c.ServerProxy.servers = {
 
 c.ServerProxy.non_service_rewrite_response = hello_to_foo
 
-import sys
-
-sys.path.append("./tests/resources")
 c.ServerApp.jpserver_extensions = {"proxyextension": True}
 c.NotebookApp.nbserver_extensions = {"proxyextension": True}
-# c.Application.log_level = 'DEBUG'

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -1,10 +1,9 @@
 import asyncio
 import gzip
-from typing import Tuple
 import json
-import os
 from http.client import HTTPConnection
 from io import BytesIO
+from typing import Tuple
 from urllib.parse import quote
 
 import pytest


### PR DESCRIPTION
## References
- fixes #309
- fixes #378 

## Code Changes
- [x] add `conftest.py`
  - [x] add a number of `@fixtures` to support starting a server
- [x] remove use of hard-coded `PORT` and `TOKEN`
  - [x] ensure coverage is captured
- [x] remove `pytest.ini`
- [x] move pytest config to `pyproject.toml`
- [x] squash some test warnings
  - [x] use `importlib(.|_)metadata` instead of `pkg_resources` (undeclared `setuptools` dep)
- [x] remove bit about starting a server before testing in `CONTRIBUTING.md`

## Future Work
- further isolate the test environment with e.g. custom `$HOME` (tricky on windows)
- split up existing `test_proxies.py` into smaller files
- potentially move some more repetitive things to fixtures
- add parameterization of `--tornado_settings base_url=/foo/bar/` to test nested paths
- fix more test warnings
  - hoist new test warnings to errors
- improve speed
  - starting a sever takes about 1.5s
  - can be challenging to get the `scope` correct with e.g. `tmp_path`
  - the widely-used `pytest-xdist` can run tests in parallel for a _moderate_ speedup, but carries some additional costs
  - some ports, etc. in the `jupyter_server_config.py`, and tests, still hard-coded, and would collide