### PR TITLE
Replace deprecated pkg_resources

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -4,7 +4,7 @@ Traitlets based configuration for jupyter_server_proxy
 from collections import namedtuple
 from warnings import warn
 
-import pkg_resources
+from importlib.metadata import entry_points
 from jupyter_server.utils import url_path_join as ujoin
 from traitlets import Dict, List, Tuple, Union, default, observe
 from traitlets.config import Configurable
@@ -90,7 +90,7 @@ def _make_supervisedproxy_handler(sp: ServerProcess):
 
 def get_entrypoint_server_processes(serverproxy_config):
     sps = []
-    for entry_point in pkg_resources.iter_entry_points("jupyter_serverproxy_servers"):
+    for entry_point in entry_points().select(group='jupyter_serverproxy_servers'):
         name = entry_point.name
         server_process_config = entry_point.load()()
         sps.append(make_server_process(name, server_process_config, serverproxy_config))

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -90,7 +90,7 @@ def _make_supervisedproxy_handler(sp: ServerProcess):
 
 def get_entrypoint_server_processes(serverproxy_config):
     sps = []
-    for entry_point in entry_points().select(group='jupyter_serverproxy_servers'):
+    for entry_point in entry_points().select(group="jupyter_serverproxy_servers"):
         name = entry_point.name
         server_process_config = entry_point.load()()
         sps.append(make_server_process(name, server_process_config, serverproxy_config))


### PR DESCRIPTION
Closes #378 

I just replaced the `pkg_resources` function with the corresponding `Importlib.metadata` calls. 


Old code, explodes:

```
import pkg_resources

for entry_point in pkg_resources.iter_entry_points('jupyter_serverproxy_servers'):
    name = entry_point.name
    print(name)
    server_process_config = entry_point.load()()
    print(server_process_config)
```

New code, might explode behind closed doors:

```
from importlib.metadata import entry_points

for entry_point in entry_points().select(group='jupyter_serverproxy_servers'):
    name = entry_point.name
    print(name)
    server_process_config = entry_point.load()()
    print(server_process_config)
```