### PR TITLE
maint: update package description to not claim windows support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
     "Framework :: Jupyter :: JupyterLab :: Extensions",
     "License :: OSI Approved :: BSD License",
     "Operating System :: MacOS :: MacOS X",
-    "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Our package is described to support use with windows, but we are not there yet. Pending work to support this, we remove the description that we support it.

### Related

- #147 
- #181 
- #392 
- https://github.com/jupyterhub/simpervisor/pull/26