### PR TITLE
ci: cleanup stashed SHA256 checksum before publish to PyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -98,6 +98,13 @@ jobs:
           name: dist
           path: dist
 
+      # The PyPI publishing action will try to publish this checksum file as if
+      # it was a Python package if it remains in dist, so we clean it up first.
+      - name: Cleanup SHA256SUMS
+        run: |
+          cat dist/SHA256SUMS
+          rm dist/SHA256SUMS
+
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@v1.8.5


### PR DESCRIPTION
Without this, we error as reported in https://github.com/jupyterhub/jupyter-server-proxy/issues/388#issuecomment-1516475532.

I made the PyPI release manually using the built wheel and source distribution for the 4.0.0 release though.