### PR TITLE
[wip] update to robotframework-jupyterlibrary 0.5.0a0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ test = [
 acceptance = [
     "jupyter-server-proxy[test]",
     "notebook <7",
-    "robotframework-jupyterlibrary >=0.4.2",
+    "robotframework-jupyterlibrary >=0.5.0a0",
 ]
 
 


### PR DESCRIPTION
We've started updating `robotframework-jupyterlibrary` to (also) support JupyterLab 4 and Notebook 7.

This is just kicking the tires on the pre-release. As no pin is in place here (maybe the real PR would), this seemed like the quickest way to get some feedback: when `0.5.0` final goes out, no changes _should_ be needed on this repo. I'll certainly endeavor not to break backwards compatibility, but it's nice to have some more real world data.