### PR TITLE
Ensure proxying to Unix sockets constructs separate HTTP clients

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -339,7 +339,9 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             # Port points to a Unix domain socket
             self.log.debug("Making client for Unix socket %r", self.unix_socket)
             assert host == "localhost", "Unix sockets only possible on localhost"
-            client = SimpleAsyncHTTPClient(resolver=UnixResolver(self.unix_socket))
+            client = SimpleAsyncHTTPClient(
+                force_instance=True, resolver=UnixResolver(self.unix_socket)
+            )
         else:
             client = httpclient.AsyncHTTPClient()
 


### PR DESCRIPTION
I started to experiment with serving things via Unix sockets (#337), but when I have two separate proxied services, I could only reach one via Jupyterhub; whichever one I used first would also get the requests meant for the other. This change fixes that.

This seems to be because Tornado's HTTP client objects are singletons by default - [the docs](https://www.tornadoweb.org/en/stable/httpclient.html#tornado.httpclient.AsyncHTTPClient) say:

> instances are reused as a kind of pseudo-singleton (one per [IOLoop](https://www.tornadoweb.org/en/stable/ioloop.html#tornado.ioloop.IOLoop)). The keyword argument `force_instance=True` can be used to suppress this singleton behavior. Unless `force_instance=True` is used, no arguments should be passed to the [AsyncHTTPClient](https://www.tornadoweb.org/en/stable/httpclient.html#tornado.httpclient.AsyncHTTPClient) constructor.

I think this bug would also affect proxying to a mixture of Unix sockets and TCP sockets, though I haven't tried. If you access something backed by a Unix socket first, that will get any later requests for other proxies; if you use a TCP socket first, anything on a Unix socket will be inaccessible. This should all be fixed by this change - TCP sockets will keep using the singleton HTTP client, and Unix sockets will get their own client each time.

I considered caching the HTTP client objects for Unix sockets in some other way, but it's extra complexity, and I think setting up a SimpleAsyncHTTPClient is cheap enough that we can just do it each time. :crossed_fingers: 