### PR TITLE
Work around incompatibility (missing firefox_profile arg) for acceptance tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ acceptance = [
     "jupyter-server-proxy[test]",
     "notebook <7",
     "robotframework-jupyterlibrary >=0.4.2",
+    # Work around https://github.com/robotframework/SeleniumLibrary/issues/1836
+    "selenium <4.10",
 ]
 
 


### PR DESCRIPTION
This will hopefully fix the CI failures looking like this:

```
tests/acceptance/test_acceptance.py::test_robot ==============================================================================
Acceptance :: Acceptance tests for jupyter-server-proxy                       
==============================================================================
Acceptance.Classic :: Server Proxies in Notebook Classic                      
==============================================================================
Notebook Classic Loads                                                | FAIL |
Parent suite setup failed:
TypeError: __init__() got an unexpected keyword argument 'firefox_profile'
```

https://github.com/robotframework/SeleniumLibrary/issues/1836