### PR TITLE
Declare metadata in pyproject.toml, remove hatch-nodejs-version plugin

### DIFF
--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -1,5 +1,6 @@
 from jupyter_server.utils import url_path_join as ujoin
 
+from ._version import __version__  # noqa
 from .api import IconHandler, ServersInfoHandler
 from .config import ServerProxy as ServerProxyConfig
 from .config import get_entrypoint_server_processes, make_handlers, make_server_process

--- a/jupyter_server_proxy/_version.py
+++ b/jupyter_server_proxy/_version.py
@@ -1,0 +1,4 @@
+# __version__ should be updated using tbump, based on configuration in
+# pyproject.toml, according to instructions in RELEASE.md.
+#
+__version__ = "4.1.1-0.dev"

--- a/labextension/package.json
+++ b/labextension/package.json
@@ -1,14 +1,31 @@
 {
   "name": "@jupyterhub/jupyter-server-proxy",
   "version": "4.1.1-0.dev",
+  "description": "A JupyterLab extension accompanying the PyPI package jupyter-server-proxy adding launcher items for configured server processes.",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
   "homepage": "https://github.com/jupyterhub/jupyter-server-proxy",
+  "bugs": {
+    "url": "https://github.com/jupyterhub/jupyter-server-proxy/issues"
+  },
   "license": "BSD-3-Clause",
+  "author": {
+    "name": "Ryan Lovett & Yuvi Panda",
+    "email": "rylo@berkeley.edu"
+  },
   "files": [
     "LICENSE",
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterhub/jupyter-server-proxy.git"
+  },
   "scripts": {
     "build": "jlpm run build:lib && jlpm run build:labextension:dev",
     "build:prod": "jlpm clean && jlpm run build:lib && jlpm run build:labextension",

--- a/labextension/package.json
+++ b/labextension/package.json
@@ -1,31 +1,14 @@
 {
   "name": "@jupyterhub/jupyter-server-proxy",
   "version": "4.1.1-0.dev",
-  "description": "A JupyterLab extension accompanying the PyPI package jupyter-server-proxy adding launcher items for configured server processes.",
-  "keywords": [
-    "jupyter",
-    "jupyterlab",
-    "jupyterlab-extension"
-  ],
   "homepage": "https://github.com/jupyterhub/jupyter-server-proxy",
-  "bugs": {
-    "url": "https://github.com/jupyterhub/jupyter-server-proxy/issues"
-  },
   "license": "BSD-3-Clause",
-  "author": {
-    "name": "Ryan Lovett & Yuvi Panda",
-    "email": "rylo@berkeley.edu"
-  },
   "files": [
     "LICENSE",
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterhub/jupyter-server-proxy.git"
-  },
   "scripts": {
     "build": "jlpm run build:lib && jlpm run build:labextension:dev",
     "build:prod": "jlpm clean && jlpm run build:lib && jlpm run build:labextension",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requires = [
 #
 [project]
 name = "jupyter_server_proxy"
+version = "4.1.1-0.dev"
 description = "A Jupyter server extension to run additional processes and proxy to them that comes bundled JupyterLab extension to launch pre-defined processes."
 keywords = ["jupyter", "jupyterlab", "jupyterlab-extension"]
 authors = [
@@ -23,7 +24,6 @@ authors = [
   { name = "Yuvi Panda", email = "yuvipanda@gmail.com" },
   { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
-dynamic = ["version"]
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
@@ -83,9 +83,6 @@ Tracker = "https://github.com/jupyterhub/jupyter-server-proxy/issues"
 
 # hatch ref: https://hatch.pypa.io/latest/
 #
-[tool.hatch.version]
-path = "jupyter_server_proxy/_version.py"
-
 [tool.hatch.build.targets.sdist]
 artifacts = [
     "jupyter_server_proxy/labextension",
@@ -189,6 +186,9 @@ regex = '''
 [tool.tbump.git]
 message_template = "Bump to {new_version}"
 tag_template = "v{new_version}"
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
 
 [[tool.tbump.file]]
 src = "labextension/package.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires = [
 #
 [project]
 name = "jupyter_server_proxy"
-description = "A JupyterLab extension accompanying the PyPI package jupyter-server-proxy adding launcher items for configured server processes."
+description = "A Jupyter server extension to run additional processes and proxy to them that comes bundled JupyterLab extension to launch pre-defined processes."
 keywords = ["jupyter", "jupyterlab", "jupyterlab-extension"]
 authors = [
   { name = "Ryan Lovett", email = "rylo@berkeley.edu" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,8 @@
 [build-system]
 build-backend = "hatchling.build"
 requires = [
-    "hatch-jupyter-builder >=0.5",
-    "hatch-nodejs-version",
-    "hatchling >=1.4.0",
+    "hatch-jupyter-builder >=0.8.3",
+    "hatchling >=1.18.0",
     "jupyterlab >=4.0.6,<5.0.0a0",
 ]
 
@@ -17,13 +16,14 @@ requires = [
 #
 [project]
 name = "jupyter_server_proxy"
-dynamic = [
-    "authors",
-    "description",
-    "keywords",
-    "urls",
-    "version",
+description = "A JupyterLab extension accompanying the PyPI package jupyter-server-proxy adding launcher items for configured server processes."
+keywords = ["jupyter", "jupyterlab", "jupyterlab-extension"]
+authors = [
+  { name = "Ryan Lovett", email = "rylo@berkeley.edu" },
+  { name = "Yuvi Panda", email = "yuvipanda@gmail.com" },
+  { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
+dynamic = ["version"]
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
@@ -75,9 +75,16 @@ lab = [
     "notebook >=7",
 ]
 
+[project.urls]
+Documentation = "https://jupyter-server-proxy.readthedocs.io"
+Source = "https://github.com/jupyterhub/jupyter-server-proxy"
+Tracker = "https://github.com/jupyterhub/jupyter-server-proxy/issues"
+
+
+# hatch ref: https://hatch.pypa.io/latest/
+#
 [tool.hatch.version]
-source = "nodejs"
-path = "labextension/package.json"
+path = "jupyter_server_proxy/_version.py"
 
 [tool.hatch.build.targets.sdist]
 artifacts = [
@@ -100,10 +107,6 @@ exclude = [
 [tool.hatch.metadata]
 # Set to true to allow testing of git+https://github.com/user/repo@sha dependencies
 allow-direct-references = false
-
-[tool.hatch.metadata.hooks.nodejs]
-path = "labextension/package.json"
-fields = ["description", "authors", "urls"]
 
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = "hatch_jupyter_builder.npm_builder"


### PR DESCRIPTION
When I made a release I bumped to a dev version after, but that had `pyproject-build` start to fail. This was because the `hatch-nodejs-version` plugin didn't allow us to use a version in package.json that was `4.1.1-0.dev` which is a valid semver2 version. In helm chart's etc that require semver2 compliant versions like package.json also wants, we've ended up using the `-0.dev` version suffix as it allows us to sort that version before alpha if we make something like that sometime.

In this PR I've instead of adjusting the version 4.1.1-0.dev to something that worked with `hatch-nodejs-version` plugin adjusted to no longer use it. I've as part of this removed some metadata from package.json and put it directly in pyproject.toml. The version field wasn't put directly there, but in `_version.py`, allowing it to be inspected via an import statement by other packages.

- Closes #429