### PR TITLE
Fix double formatting of callables (`command`, `environment`, `request_headers_override`)

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -654,9 +654,7 @@ class NamedLocalProxyHandler(LocalProxyHandler):
     def _realize_rendered_template(self, attribute):
         """Call any callables, then render any templated values."""
         if callable(attribute):
-            attribute = self._render_template(
-                call_with_asked_args(attribute, self.process_args)
-            )
+            attribute = call_with_asked_args(attribute, self.process_args)
         return self._render_template(attribute)
 
     @web.authenticated

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -42,6 +42,10 @@ def cats_only(response, path):
         response.code = 403
         response.body = b"dogs not allowed"
 
+def my_env():
+    return {
+            "MYVAR": "String with escaped {{var}}"
+        }
 
 c.ServerProxy.servers = {
     "python-http": {
@@ -64,6 +68,10 @@ c.ServerProxy.servers = {
     "python-http-mappathf": {
         "command": [sys.executable, "./tests/resources/httpinfo.py", "--port={port}"],
         "mappath": mappathf,
+    },
+    "python-http-callable-env": {
+        "command": [sys.executable, "./tests/resources/httpinfo.py", "--port={port}"],
+        "environment": my_env,
     },
     "python-websocket": {
         "command": [sys.executable, "./tests/resources/websocket.py", "--port={port}"],

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -408,3 +408,9 @@ def test_bad_server_proxy_url(
     if status >= 400:
         # request should not have been proxied
         assert "X-ProxyContextPath" not in r.headers
+
+
+def test_callable_environment_formatting(a_server_port_and_token: Tuple[int, str]) -> None:
+    PORT, TOKEN = a_server_port_and_token
+    r = request_get(PORT, "/python-http-callable-env/test", TOKEN)
+    assert r.code == 200


### PR DESCRIPTION
If a server has a callable as the environment, jupyter-server-proxy formatted it twice. 

If that callable returned an escaped var (i.e. `{ "MYVAR": "{{var}}" }`), the server was crashing when doing the second formatting (as "var" does not exist).

```python
>>> myVar = "{{var}}"
>>> myVar = myVar.format({})
>>> myVar = myVar.format({})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'var'
```

With this PR I only format once, wether it's callable or dict.