### PR TITLE
Prevent failed entrypoints from spoiling the bunch

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -97,7 +97,11 @@ def get_entrypoint_server_processes(serverproxy_config):
     sps = []
     for entry_point in entry_points(group="jupyter_serverproxy_servers"):
         name = entry_point.name
-        server_process_config = entry_point.load()()
+        try:
+            server_process_config = entry_point.load()()
+        except Exception as e:
+            warn(f"entry_point {name} was unable to be loaded: {str(e)}")
+            continue
         sps.append(make_server_process(name, server_process_config, serverproxy_config))
     return sps
 


### PR DESCRIPTION
I'm not totally sure if this is the fix I need, but I think it is... full disclaimer, I did not test/validate this.

I am in a JupyterLab environment where many servers are registered under the jupyter-server-proxy entrypoints and occassionaly one of them might fail. Trouble is that if one fails, they all fail and no servers are able to be registered and launched (or maybe just subsequent entrypoints fail to register?).

I'd like for jupyter-server-proxy to gracefully handle failures when loading entrypoints so as to not let one failed entrypoint prevent others from loading.

Looking forward to any feedback on these changes and if you all think this would do it