### PR TITLE
Add `raw_socket_proxy` to directly proxy websockets to TCP/unix sockets

### DIFF
--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -153,6 +153,18 @@ One of:
 
 (server-process:callable-arguments)=
 
+### `websockify`
+
+_True_ to proxy only websocket connections into raw stream connections.
+_False_ (default) if the proxied server speaks full HTTP.
+
+If _True_, the proxied server is treated a raw TCP (or unix socket) server that
+does not use HTTP.
+In this mode, only websockets are handled, and messages are sent to the backend
+server as stream data. This is equivalent to running a
+[websockify](https://github.com/novnc/websockify) wrapper.
+All other HTTP requests return 405.
+
 #### Callable arguments
 
 Any time you specify a callable in the config, it can ask for any arguments it needs

--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -169,7 +169,7 @@ Defaults to _True_.
 
 (server-process:callable-arguments)=
 
-### `websockify`
+### `raw_socket_proxy`
 
 _True_ to proxy only websocket connections into raw stream connections.
 _False_ (default) if the proxied server speaks full HTTP.
@@ -177,7 +177,7 @@ _False_ (default) if the proxied server speaks full HTTP.
 If _True_, the proxied server is treated a raw TCP (or unix socket) server that
 does not use HTTP.
 In this mode, only websockets are handled, and messages are sent to the backend
-server as stream data. This is equivalent to running a
+server as raw stream data. This is similar to running a
 [websockify](https://github.com/novnc/websockify) wrapper.
 All other HTTP requests return 405.
 

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -291,7 +291,7 @@ class ServerProxy(Configurable):
             Proxy websocket requests as a TCP (or unix socket) stream.
             In this mode, only websockets are handled, and messages are sent to the backend,
             equivalent to running a websockify layer (https://github.com/novnc/websockify).
-            All other HTTP requests return 405.
+            All other HTTP requests return 405 (and thus this will also bypass rewrite_response).
         """,
         config=True,
     )

--- a/jupyter_server_proxy/rawsocket.py
+++ b/jupyter_server_proxy/rawsocket.py
@@ -2,7 +2,7 @@
 A simple translation layer between tornado websockets and asyncio stream
 connections.
 
-This subsumes the functionality of websockify
+This provides similar functionality to websockify
 (https://github.com/novnc/websockify) without needing an extra proxy hop
 or process through with all messages pass for translation.
 """
@@ -11,7 +11,7 @@ import asyncio
 
 from .handlers import NamedLocalProxyHandler, SuperviseAndProxyHandler
 
-class WebsockifyProtocol(asyncio.Protocol):
+class RawSocketProtocol(asyncio.Protocol):
     """
     A protocol handler for the proxied stream connection.
     Sends any received blocks directly as websocket messages.
@@ -22,15 +22,16 @@ class WebsockifyProtocol(asyncio.Protocol):
     def data_received(self, data):
         "Send the buffer as a websocket message."
         self.handler._record_activity()
-        # async "semi-synchronous", waiting is only needed for control flow and errors:
+        # ignore async "semi-synchronous" result, waiting is only needed for control flow and errors
+        # (see https://github.com/tornadoweb/tornado/blob/bdfc017c66817359158185561cee7878680cd841/tornado/websocket.py#L1073)
         self.handler.write_message(data, binary=True)
 
     def connection_lost(self, exc):
         "Close the websocket connection."
-        self.handler.log.info(f"Websockify {self.handler.name} connection lost: {exc}")
+        self.handler.log.info(f"Raw websocket {self.handler.name} connection lost: {exc}")
         self.handler.close()
 
-class WebsockifyHandler(NamedLocalProxyHandler):
+class RawSocketHandler(NamedLocalProxyHandler):
     """
     HTTP handler that proxies websocket connections into a backend stream.
     All other HTTP requests return 405.
@@ -39,33 +40,32 @@ class WebsockifyHandler(NamedLocalProxyHandler):
         "Create the appropriate backend asyncio connection"
         loop = asyncio.get_running_loop()
         if self.unix_socket is not None:
-            self.log.info(f"Websockify {self.name} connecting to {self.unix_socket}")
+            self.log.info(f"RawSocket {self.name} connecting to {self.unix_socket}")
             return loop.create_unix_connection(proto, self.unix_socket)
         else:
-            self.log.info(f"Websockify {self.name} connecting to port {self.port}")
+            self.log.info(f"RawSocket {self.name} connecting to port {self.port}")
             return loop.create_connection(proto, 'localhost', self.port)
 
     async def proxy(self, port, path):
-        raise web.HTTPError(405, "websockets only")
+        raise web.HTTPError(405, "this raw_socket_proxy backend only supports websocket connections")
 
     async def proxy_open(self, host, port, proxied_path=""):
         """
         Open the backend connection. host and port are ignored (as they are in
         the parent for unix sockets) since they are always passed known values.
         """
-        transp, proto = await self._create_ws_connection(lambda: WebsockifyProtocol(self))
+        transp, proto = await self._create_ws_connection(lambda: RawSocketProtocol(self))
         self.ws_transp = transp
         self.ws_proto = proto
         self._record_activity()
-        self.log.info(f"Websockify {self.name} connected")
+        self.log.info(f"RawSocket {self.name} connected")
 
     def on_message(self, message):
         "Send websocket messages as stream writes, encoding if necessary."
         self._record_activity()
-        if hasattr(self, "ws_transp"):
-            if isinstance(message, str):
-                message = message.encode('utf-8')
-            self.ws_transp.write(message) # buffered non-blocking. should block?
+        if isinstance(message, str):
+            message = message.encode('utf-8')
+        self.ws_transp.write(message) # buffered non-blocking. should block (needs new enough tornado)
 
     def on_ping(self, message):
         "No-op"
@@ -73,17 +73,17 @@ class WebsockifyHandler(NamedLocalProxyHandler):
 
     def on_close(self):
         "Close the backend connection."
-        self.log.info(f"Websockify {self.name} connection closed")
+        self.log.info(f"RawSocket {self.name} connection closed")
         if hasattr(self, "ws_transp"):
             self.ws_transp.close()
 
-class SuperviseAndWebsockifyHandler(SuperviseAndProxyHandler, WebsockifyHandler):
+class SuperviseAndRawSocketHandler(SuperviseAndProxyHandler, RawSocketHandler):
     async def _http_ready_func(self, p):
         # not really HTTP here, just try an empty connection
         try:
             transp, _ = await self._create_ws_connection(asyncio.Protocol)
         except OSError as exc:
-            self.log.debug(f"Websockify {self.name} connection check failed: {exc}")
+            self.log.debug(f"RawSocket {self.name} connection check failed: {exc}")
             return False
         transp.close()
         return True

--- a/jupyter_server_proxy/websockify.py
+++ b/jupyter_server_proxy/websockify.py
@@ -1,0 +1,88 @@
+"""
+A simple translation layer between tornado websockets and asyncio stream
+connections.
+
+This subsumes the functionality of websockify
+(https://github.com/novnc/websockify) without needing an extra proxy hop
+or process through with all messages pass for translation.
+"""
+
+import asyncio
+
+from .handlers import NamedLocalProxyHandler, SuperviseAndProxyHandler
+
+class WebsockifyProtocol(asyncio.Protocol):
+    """
+    A protocol handler for the proxied stream connection.
+    Sends any received blocks directly as websocket messages.
+    """
+    def __init__(self, handler):
+        self.handler = handler
+
+    def data_received(self, data):
+        "Send the buffer as a websocket message."
+        self.handler._record_activity()
+        self.handler.write_message(data, binary=True) # async, no wait
+
+    def connection_lost(self, exc):
+        "Close the websocket connection."
+        self.handler.log.info(f"Websockify {self.handler.name} connection lost: {exc}")
+        self.handler.close()
+
+class WebsockifyHandler(NamedLocalProxyHandler):
+    """
+    HTTP handler that proxies websocket connections into a backend stream.
+    All other HTTP requests return 405.
+    """
+    def _create_ws_connection(self, proto: asyncio.BaseProtocol):
+        "Create the appropriate backend asyncio connection"
+        loop = asyncio.get_running_loop()
+        if self.unix_socket is not None:
+            self.log.info(f"Websockify {self.name} connecting to {self.unix_socket}")
+            return loop.create_unix_connection(proto, self.unix_socket)
+        else:
+            self.log.info(f"Websockify {self.name} connecting to port {self.port}")
+            return loop.create_connection(proto, 'localhost', self.port)
+
+    async def proxy(self, port, path):
+        raise web.HTTPError(405, "websockets only")
+
+    async def proxy_open(self, host, port, proxied_path=""):
+        """
+        Open the backend connection. host and port are ignored (as they are in
+        the parent for unix sockets) since they are always passed known values.
+        """
+        transp, proto = await self._create_ws_connection(lambda: WebsockifyProtocol(self))
+        self.ws_transp = transp
+        self.ws_proto = proto
+        self._record_activity()
+        self.log.info(f"Websockify {self.name} connected")
+
+    def on_message(self, message):
+        "Send websocket messages as stream writes, encoding if necessary."
+        self._record_activity()
+        if hasattr(self, "ws_transp"):
+            if isinstance(message, str):
+                message = message.encode('utf-8')
+            self.ws_transp.write(message) # buffered non-blocking. should block?
+
+    def on_ping(self, message):
+        "No-op"
+        self._record_activity()
+
+    def on_close(self):
+        "Close the backend connection."
+        self.log.info(f"Websockify {self.name} connection closed")
+        if hasattr(self, "ws_transp"):
+            self.ws_transp.close()
+
+class SuperviseAndWebsockifyHandler(SuperviseAndProxyHandler, WebsockifyHandler):
+    async def _http_ready_func(self, p):
+        # not really HTTP here, just try an empty connection
+        try:
+            transp, _ = await self._create_ws_connection(asyncio.Protocol)
+        except OSError as exc:
+            self.log.debug(f"Websockify {self.name} connection check failed: {exc}")
+            return False
+        transp.close()
+        return True

--- a/jupyter_server_proxy/websockify.py
+++ b/jupyter_server_proxy/websockify.py
@@ -22,7 +22,8 @@ class WebsockifyProtocol(asyncio.Protocol):
     def data_received(self, data):
         "Send the buffer as a websocket message."
         self.handler._record_activity()
-        self.handler.write_message(data, binary=True) # async, no wait
+        # async "semi-synchronous", waiting is only needed for control flow and errors:
+        self.handler.write_message(data, binary=True)
 
     def connection_lost(self, exc):
         "Close the websocket connection."

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -127,6 +127,15 @@ c.ServerProxy.servers = {
         "rewrite_response": [cats_only, dog_to_cat],
     },
     "python-proxyto54321-no-command": {"port": 54321},
+    "python-rawsocket-tcp": {
+        "command": [sys.executable, "./tests/resources/rawsocket.py", "{port}"],
+        "raw_socket_proxy": True
+    },
+    "python-rawsocket-unix": {
+        "command": [sys.executable, "./tests/resources/rawsocket.py", "{unix_socket}"],
+        "unix_socket": True,
+        "raw_socket_proxy": True
+    },
 }
 
 c.ServerProxy.non_service_rewrite_response = hello_to_foo

--- a/tests/resources/rawsocket.py
+++ b/tests/resources/rawsocket.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import os
+import socket
+import sys
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} TCPPORT|SOCKPATH")
+    sys.exit(1)
+where = sys.argv[1]
+try:
+    port = int(where)
+    family = socket.AF_INET
+    addr = ('localhost', port)
+except ValueError:
+    family = socket.AF_UNIX
+    addr = where
+
+with socket.create_server(addr, family=family, reuse_port=True) as serv:
+    while True:
+        # only handle a single connection at a time
+        sock, caddr = serv.accept()
+        while True:
+            s = sock.recv(1024)
+            if not s:
+                break
+            sock.send(s.swapcase())
+        sock.close()

--- a/tests/resources/rawsocket.py
+++ b/tests/resources/rawsocket.py
@@ -16,7 +16,7 @@ except ValueError:
     family = socket.AF_UNIX
     addr = where
 
-with socket.create_server(addr, family=family, reuse_port=True) as serv:
+with socket.create_server(addr, family=family) as serv:
     while True:
         # only handle a single connection at a time
         sock, caddr = serv.accept()


### PR DESCRIPTION
This incorporates the functionality of websockify by allowing websockets to be proxied to simple TCP or unix socket streams. 

While I understand that websockify already provides a working solution to this problem (see discussion on #75), this seems to have a number of benefits, mainly that it eliminates the extra proxy layer and process that websockify imposes, improving latency and performance overall. It does so with a fairly small amount of code, much smaller and ismpler than websockify itself.

To simplify the instantiation of proxy handlers, this also generalizes and combines the `_make_namedproxy_handler` and `_make_supervisedproxy_handler` functions into a single `_make_proxy_handler` that dynamically determines the class to use, improving flexibility and reducing code duplication, at the cost of a little complexity.