### PR TITLE
ci: schedule test runs twice a week

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,9 @@ on:
     branches-ignore:
       - "dependabot/**"
       - "pre-commit-ci-update-config"
+  schedule:
+    # Run at 05:00 on monday and thursday, ref: https://crontab.guru/#0_5_*_*_1,4
+    - cron: "0 5 * * 1,4"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
We had test failures in main branch (#449), and realizing that something has started failing is often something that goes with tracking what dependencies has changed.

If I think there is a test that has started failing for some reason outside a code change in repo, I do the following:

1. Look at workflows run recently to identify when they last worked and when they started failing
2. Compare `pip freeze` output between succeeding tests and failing tests by copy pasting into `ok.txt` and `fail.txt` and doing `git diff --no-index -U0 -- ok.txt fail.txt` (-U0 means 0 lines of context surrounding changes observed)

This is troublesome if there isn't a workflow run recently though, but having regular runs, for example twice a week, would do the trick.