### PR TITLE
Allow configuring jupyterlab launcher category

### DIFF
--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -123,9 +123,15 @@ the following keys:
    explicit entry.
 2. **icon_path**
    Full path to an svg icon that could be used with a launcher. Currently only used by the
-   JupyterLab launcher
+   JupyterLab launcher, when category is "Notebook" (default) or "Console".
 3. **title**
    Title to be used for the launcher entry. Defaults to the name of the server if missing.
+4. **path_info**
+   The trailing path that is appended to the user's server URL to access the proxied server.
+   By default it is the name of the server followed by a trailing slash.
+5. **category**
+   The category for the launcher item. Currently only used by the JupyterLab launcher.
+   By default it is "Notebook".
 
 ### `new_browser_tab`
 

--- a/jupyter_server_proxy/api.py
+++ b/jupyter_server_proxy/api.py
@@ -22,6 +22,7 @@ class ServersInfoHandler(JupyterHandler):
                     "enabled": sp.launcher_entry.enabled,
                     "title": sp.launcher_entry.title,
                     "path_info": sp.launcher_entry.path_info,
+                    "category": sp.launcher_entry.category,
                 },
                 "new_browser_tab": sp.new_browser_tab,
             }

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -24,7 +24,7 @@ except ImportError:
 
 
 LauncherEntry = namedtuple(
-    "LauncherEntry", ["enabled", "icon_path", "title", "path_info"]
+    "LauncherEntry", ["enabled", "icon_path", "title", "path_info", "category"]
 )
 ServerProcess = namedtuple(
     "ServerProcess",
@@ -148,6 +148,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
             icon_path=le.get("icon_path"),
             title=le.get("title", name),
             path_info=le.get("path_info", name + "/"),
+            category=le.get("category", "Notebook"),
         ),
         new_browser_tab=server_process_config.get("new_browser_tab", True),
         request_headers_override=server_process_config.get(
@@ -229,6 +230,10 @@ class ServerProxy(Configurable):
               path_info
                 The trailing path that is appended to the user's server URL to access the proxied server.
                 By default it is the name of the server followed by a trailing slash.
+
+              category
+                The category for the launcher item. Currently only used by the JupyterLab launcher.
+                By default it is "Notebook".
 
           new_browser_tab
             Set to True (default) to make the proxied server interface opened as a new browser tab. Set to False

--- a/labextension/src/index.ts
+++ b/labextension/src/index.ts
@@ -202,7 +202,7 @@ async function activate(
       launcher.add({
         command: CommandIDs.open,
         args: argsForServer(server_process),
-        category: "Notebook",
+        category: launcher_entry.category,
         kernelIconUrl: launcher_entry.icon_url || void 0,
       });
     }

--- a/labextension/src/tokens.ts
+++ b/labextension/src/tokens.ts
@@ -102,4 +102,5 @@ export interface ILauncherEntry {
   path_info: string;
   // the `?` means this argument may not exist, but if it does, it must be a string
   icon_url?: string;
+  category?: string;
 }


### PR DESCRIPTION
This lets you set which row of the launcher the icon ends up on (Notebook, Console, or Other).  Just pass a configured launcher_entry.category through to launcher.add, defaulting to Notebook. Also adds documentation for existing `path_info` which was missing.