### PR TITLE
Fix failure to upload code coverage reports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -163,5 +163,3 @@ jobs:
 
       # GitHub action reference: https://github.com/codecov/codecov-action
       - uses: codecov/codecov-action@v4
-        with:
-          directory: build/.coverage


### PR DESCRIPTION
The code coverage action didn't find a data file of relevance to upload (`coverage.xml`). I've now made sure it finds it.

Things improved, but its messy due to launching `pytest` from the `build` folder.