### PR TITLE
List tornado and traitlets as dependencies explicitly, and cleanup unreachable code

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,7 @@ jobs:
         os: [ubuntu-22.04, windows-2022]
         python-version: ["3.8", "3.11"]
         pip-extras: ["lab", "classic"]
+        pip-install-constraints: [""]
         exclude:
           # windows should work for all test variations, but a limited selection
           # is run to avoid doubling the amount of test runs
@@ -85,6 +86,17 @@ jobs:
           - os: windows-2022
             python-version: "3.8"
             pip-extras: lab
+
+          # this test is manually updated to reflect the lower bounds of
+          # versions from dependencies
+          - os: ubuntu-22.04
+            python-version: "3.8"
+            pip-extras: classic
+            pip-install-constraints: >-
+              jupyter-server==1.0
+              simpervisor==1.0
+              tornado==5.0
+              traitlets==4.2.1
 
     steps:
       - uses: actions/checkout@v4
@@ -108,7 +120,7 @@ jobs:
         #
         #       Pytest options are set in `pyproject.toml`.
         run: |
-          pip install -vv $(ls ./dist/*.whl)\[acceptance,${{ matrix.pip-extras }}\]
+          pip install -vv $(ls ./dist/*.whl)\[acceptance,${{ matrix.pip-extras }}\] ${{ matrix.pip-install-constraints }}
 
       - name: List Python packages
         run: |

--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -7,7 +7,7 @@ Some original inspiration from https://github.com/senko/tornado-proxy
 import inspect
 
 from jupyter_server.utils import ensure_async
-from tornado import httpclient, httputil, ioloop, version_info, websocket
+from tornado import httpclient, httputil, websocket
 
 
 class PingableWSClientConnection(websocket.WebSocketClientConnection):
@@ -40,31 +40,21 @@ def pingable_ws_connect(
     request.headers = httputil.HTTPHeaders(request.headers)
     request = httpclient._RequestProxy(request, httpclient.HTTPRequest._DEFAULTS)
 
-    # for tornado 4.5.x compatibility
-    if version_info[0] == 4:
-        conn = PingableWSClientConnection(
-            io_loop=ioloop.IOLoop.current(),
-            compression_options={},
-            request=request,
-            on_message_callback=on_message_callback,
-            on_ping_callback=on_ping_callback,
-        )
-    else:
-        # resolver= parameter requires tornado >= 6.3. Only pass it if needed
-        # (for Unix socket support), so older versions of tornado can still
-        # work otherwise.
-        kwargs = {"resolver": resolver} if resolver else {}
-        conn = PingableWSClientConnection(
-            request=request,
-            compression_options={},
-            on_message_callback=on_message_callback,
-            on_ping_callback=on_ping_callback,
-            max_message_size=getattr(
-                websocket, "_default_max_message_size", 10 * 1024 * 1024
-            ),
-            subprotocols=subprotocols,
-            **kwargs,
-        )
+    # resolver= parameter requires tornado >= 6.3. Only pass it if needed
+    # (for Unix socket support), so older versions of tornado can still
+    # work otherwise.
+    kwargs = {"resolver": resolver} if resolver else {}
+    conn = PingableWSClientConnection(
+        request=request,
+        compression_options={},
+        on_message_callback=on_message_callback,
+        on_ping_callback=on_ping_callback,
+        max_message_size=getattr(
+            websocket, "_default_max_message_size", 10 * 1024 * 1024
+        ),
+        subprotocols=subprotocols,
+        **kwargs,
+    )
 
     return conn.connect_future
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ dependencies = [
     "importlib_metadata >=4.8.3 ; python_version<\"3.10\"",
     "jupyter-server >=1.0",
     "simpervisor >=1.0",
+    "tornado >=5.0",
+    "traitlets >= 4.2.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
We reference tornado and traitlets directly from our source code, so we should surface those dependecies.

We require `jupyter-server>=1.0`, which [depend on `tornado>=5.0` and `traitlets>=4.2.1`](https://github.com/jupyter-server/jupyter_server/blob/1.0.0/setup.py#L39), so I'm adding our dependency on tornado and traitlets explicitly in this project, putting their lower bounds to those versions - and adding a test to verify our test suite works against those versions.

For reference, note that `jupyter-server==1.1.0` released four years ago requires tornado 6.1, so I figure its safe to assume we can bump these notably without issues in the future.

---

This enables me to better reason about https://github.com/jupyterhub/jupyter-server-proxy/pull/448, as its changing something that is passed to tornado, and tornado's behavior may differ slightly between versions.