### PR TITLE
Ensure no blank `Sec-Websocket-Protocol` headers and warn if websocket subprotocol edge case occur

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,7 +95,7 @@ jobs:
             pip-install-constraints: >-
               jupyter-server==1.0
               simpervisor==1.0
-              tornado==5.0
+              tornado==5.1
               traitlets==4.2.1
 
     steps:

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -500,6 +500,16 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             )
             self._record_activity()
             self.log.info(f"Websocket connection established to {client_uri}")
+            if (
+                subprotocols
+                and self.ws.selected_subprotocol != self.selected_subprotocol
+            ):
+                self.log.warn(
+                    f"Websocket subprotocol between proxy/server ({self.ws.selected_subprotocol}) "
+                    f"became different than for client/proxy ({self.selected_subprotocol}) "
+                    "due to https://github.com/jupyterhub/jupyter-server-proxy/issues/459. "
+                    f"Requested subprotocols were {subprotocols}."
+                )
 
         # Wait for the WebSocket to be connected before resolving.
         # Otherwise, messages sent by the client before the
@@ -539,7 +549,8 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         Note that this subprotocol selection should really be delegated to the
         server we proxy to, but we don't! For this to happen, we would need to
         delay accepting the handshake with the client until we have successfully
-        handshaked with the server.
+        handshaked with the server. This issue is tracked via
+        https://github.com/jupyterhub/jupyter-server-proxy/issues/459.
 
         Overrides `tornado.websocket.WebSocketHandler.select_subprotocol` that
         includes an informative docstring:
@@ -549,7 +560,6 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             self.log.debug(
                 f"Client sent subprotocols: {subprotocols}, selecting the first"
             )
-            # TODO: warn if we select one out of multiple!
             return subprotocols[0]
         return None
 

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -546,10 +546,6 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         https://github.com/tornadoweb/tornado/blob/v6.4.0/tornado/websocket.py#L337-L360.
         """
         if subprotocols:
-            # Tornado 5.0 doesn't pass an empty list, but a list with a an empty
-            # string element.
-            if subprotocols[0] == "":
-                return None
             self.log.debug(
                 f"Client sent subprotocols: {subprotocols}, selecting the first"
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "importlib_metadata >=4.8.3 ; python_version<\"3.10\"",
     "jupyter-server >=1.0",
     "simpervisor >=1.0",
-    "tornado >=5.0",
+    "tornado >=5.1",
     "traitlets >= 4.2.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest",
+    "pytest-asyncio",
     "pytest-cov",
     "pytest-html",
 ]
@@ -195,11 +196,16 @@ src = "pyproject.toml"
 [[tool.tbump.file]]
 src = "labextension/package.json"
 
+
+# pytest is used for running Python based tests
+#
+# ref: https://docs.pytest.org/en/stable/
+#
 [tool.pytest.ini_options]
-cache_dir = "build/.cache/pytest"
-testpaths = ["tests"]
 addopts = [
-    "-vv",
+    "--verbose",
+    "--durations=10",
+    "--color=yes",
     "--cov=jupyter_server_proxy",
     "--cov-branch",
     "--cov-context=test",
@@ -207,9 +213,16 @@ addopts = [
     "--cov-report=html:build/coverage",
     "--no-cov-on-fail",
     "--html=build/pytest/index.html",
-    "--color=yes",
 ]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+cache_dir = "build/.cache/pytest"
 
+
+# pytest-cov / coverage is used to measure code coverage of tests
+#
+# ref: https://coverage.readthedocs.io/en/stable/config.html
+#
 [tool.coverage.run]
 data_file = "build/.coverage"
 concurrency = [

--- a/tests/resources/websocket.py
+++ b/tests/resources/websocket.py
@@ -68,18 +68,34 @@ class HeadersWebSocket(tornado.websocket.WebSocketHandler):
 
 
 class SubprotocolWebSocket(tornado.websocket.WebSocketHandler):
-    """Echoes back incoming requested subprotocols."""
+    """
+    Echoes back requested subprotocols and selected subprotocol as a JSON
+    encoded message, and selects subprotocols in a very particular way to help
+    us test things.
+    """
 
     def __init__(self, *args, **kwargs):
-        self._subprotocols = None
+        self._requested_subprotocols = None
         super().__init__(*args, **kwargs)
 
     def select_subprotocol(self, subprotocols):
-        self._subprotocols = subprotocols
-        return None
+        self._requested_subprotocols = subprotocols if subprotocols else None
+
+        if not subprotocols:
+            return None
+        if "please_select_no_protocol" in subprotocols:
+            return None
+        if "favored" in subprotocols:
+            return "favored"
+        else:
+            return subprotocols[0]
 
     def on_message(self, message):
-        self.write_message(json.dumps(self._subprotocols))
+        response = {
+            "requested_subprotocols": self._requested_subprotocols,
+            "selected_subprotocol": self.selected_subprotocol,
+        }
+        self.write_message(json.dumps(response))
 
 
 def main():

--- a/tests/resources/websocket.py
+++ b/tests/resources/websocket.py
@@ -54,16 +54,22 @@ class MainHandler(tornado.web.RequestHandler):
 
 
 class EchoWebSocket(tornado.websocket.WebSocketHandler):
+    """Echoes back received messages."""
+
     def on_message(self, message):
         self.write_message(message)
 
 
 class HeadersWebSocket(tornado.websocket.WebSocketHandler):
+    """Echoes back incoming request headers."""
+
     def on_message(self, message):
         self.write_message(json.dumps(dict(self.request.headers)))
 
 
 class SubprotocolWebSocket(tornado.websocket.WebSocketHandler):
+    """Echoes back incoming requested subprotocols."""
+
     def __init__(self, *args, **kwargs):
         self._subprotocols = None
         super().__init__(*args, **kwargs)

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -1,4 +1,3 @@
-import asyncio
 import gzip
 import json
 import sys
@@ -332,14 +331,9 @@ def test_server_content_encoding_header(
         assert f.read() == b"this is a test"
 
 
-@pytest.fixture(scope="module")
-def event_loop():
-    loop = asyncio.get_event_loop()
-    yield loop
-    loop.close()
-
-
-async def _websocket_echo(a_server_port_and_token: Tuple[int, str]) -> None:
+async def test_server_proxy_websocket_messages(
+    a_server_port_and_token: Tuple[int, str]
+) -> None:
     PORT = a_server_port_and_token[0]
     url = f"ws://{LOCALHOST}:{PORT}/python-websocket/echosocket"
     conn = await websocket_connect(url)
@@ -349,13 +343,7 @@ async def _websocket_echo(a_server_port_and_token: Tuple[int, str]) -> None:
     assert msg == expected_msg
 
 
-def test_server_proxy_websocket(
-    event_loop, a_server_port_and_token: Tuple[int, str]
-) -> None:
-    event_loop.run_until_complete(_websocket_echo(a_server_port_and_token))
-
-
-async def _websocket_headers(a_server_port_and_token: Tuple[int, str]) -> None:
+async def test_server_proxy_websocket_headers(a_server_port_and_token: Tuple[int, str]):
     PORT = a_server_port_and_token[0]
     url = f"ws://{LOCALHOST}:{PORT}/python-websocket/headerssocket"
     conn = await websocket_connect(url)
@@ -366,25 +354,15 @@ async def _websocket_headers(a_server_port_and_token: Tuple[int, str]) -> None:
     assert headers["X-Custom-Header"] == "pytest-23456"
 
 
-def test_server_proxy_websocket_headers(
-    event_loop, a_server_port_and_token: Tuple[int, str]
+async def test_server_proxy_websocket_subprotocols(
+    a_server_port_and_token: Tuple[int, str]
 ):
-    event_loop.run_until_complete(_websocket_headers(a_server_port_and_token))
-
-
-async def _websocket_subprotocols(a_server_port_and_token: Tuple[int, str]) -> None:
     PORT, TOKEN = a_server_port_and_token
     url = f"ws://{LOCALHOST}:{PORT}/python-websocket/subprotocolsocket"
     conn = await websocket_connect(url, subprotocols=["protocol_1", "protocol_2"])
     await conn.write_message("Hello, world!")
     msg = await conn.read_message()
     assert json.loads(msg) == ["protocol_1"]
-
-
-def test_server_proxy_websocket_subprotocols(
-    event_loop, a_server_port_and_token: Tuple[int, str]
-):
-    event_loop.run_until_complete(_websocket_subprotocols(a_server_port_and_token))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -378,7 +378,7 @@ async def _websocket_subprotocols(a_server_port_and_token: Tuple[int, str]) -> N
     conn = await websocket_connect(url, subprotocols=["protocol_1", "protocol_2"])
     await conn.write_message("Hello, world!")
     msg = await conn.read_message()
-    assert json.loads(msg) == ["protocol_1", "protocol_2"]
+    assert json.loads(msg) == ["protocol_1"]
 
 
 def test_server_proxy_websocket_subprotocols(
@@ -410,7 +410,9 @@ def test_bad_server_proxy_url(
         assert "X-ProxyContextPath" not in r.headers
 
 
-def test_callable_environment_formatting(a_server_port_and_token: Tuple[int, str]) -> None:
+def test_callable_environment_formatting(
+    a_server_port_and_token: Tuple[int, str]
+) -> None:
     PORT, TOKEN = a_server_port_and_token
     r = request_get(PORT, "/python-http-callable-env/test", TOKEN)
     assert r.code == 200


### PR DESCRIPTION
This PR ensures we don't pass a blank `Sec-Websocket-Protocol` header ([Sending a blank header is incorrect](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers#subprotocols)) when we proxy a websocket. This fixes #442, fixes #445, is assumed to fix #332, and closes #448.

This project currently proxies websockets by first accepting an incomming websocket connection were a subprotocol is established, and then opening a websocket connection to a server to proxy to. This is a problem and can lead to bugs that we now warn about. This PR adds tests to document our current problematic handling.

Thank you @duytnguyendtn, @zoghbi-a, and @benz0li for working this - this is building a lot on their investigation and conclusions, which were critical as I didn't understand much about this before.