### PR TITLE
Keep proxying all requested subprotocols

### DIFF
--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -360,6 +360,7 @@ async def test_server_proxy_websocket_headers(a_server_port_and_token: Tuple[int
     [
         (None, None, None, None),
         (["first"], ["first"], "first", "first"),
+        (["first", "second"], ["first", "second"], "first", "first"),
         # IMPORTANT: The tests below verify current bugged behavior, and the
         #            commented out tests is what we want to succeed!
         #
@@ -369,14 +370,12 @@ async def test_server_proxy_websocket_headers(a_server_port_and_token: Tuple[int
         #            before the proxy/server handshake, and that makes it
         #            impossible. We currently instead just pick the first
         #            requested protocol no matter what what subprotocol the
-        #            server picks.
+        #            server picks and warn if there is a mismatch retroactively.
         #
-        # Bug 1 - server wasn't passed all subprotocols:
-        (["first", "second"], ["first"], "first", "first"),
-        # (["first", "second"], ["first", "second"], "first", "first"),
+        #            Tracked in https://github.com/jupyterhub/jupyter-server-proxy/issues/459.
         #
-        # Bug 2 - server_responded doesn't match proxy_responded:
-        (["first", "favored"], ["first"], "first", "first"),
+        # Bug - server_responded doesn't match proxy_responded:
+        (["first", "favored"], ["first", "favored"], "favored", "first"),
         # (["first", "favored"], ["first", "favored"], "favored", "favored"),
         (
             ["please_select_no_protocol"],


### PR DESCRIPTION
When jupyter-server-proxy proxies websockets, its finalizes the websocket handshake between client/proxy before it initiates the proxy/server websocket handshake.

In #458 released with 4.1.1 earlier today the thinking was that it was a better compromise to not forward all subprotocol choices in the proxy/server handshake if we had prematurely picked a single choice in the client/proxy handshake. This turns out to have introduced a regression though, as at least bokeh had been using secondary subprotocol choices to pass other information such as base64 encoded JSON with keys like `session_id`, `session_expiry` and `__bk__zlib_`.

This commit makes sure we keep passing all requested subprotocols, even though we have prematurely picked a specific ahead of time - which is a bug tracked in https://github.com/jupyterhub/jupyter-server-proxy/issues/459. With this bug, we just have to pick the less buggy workaround, which may be to proxy all requested subprotocols.
