### PR TITLE
Require jupyter_server 1.24+, tornado 6.1+, traitlets 5.1+

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,10 +94,10 @@ jobs:
             python-version: "3.8"
             pip-extras: classic
             pip-install-constraints: >-
-              jupyter-server==1.0
-              simpervisor==1.0
-              tornado==5.1
-              traitlets==4.2.1
+              jupyter-server==1.24.0
+              simpervisor==1.0.0
+              tornado==6.1.0
+              traitlets==5.1.0
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,7 @@ jobs:
           path: ./dist
 
   test:
-    name: ${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.pip-extras }}
+    name: ${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.pip-extras }} ${{ (matrix.pip-install-constraints != '' && '(oldest deps)') || '' }}
     needs: [build]
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
@@ -87,6 +87,7 @@ jobs:
             python-version: "3.8"
             pip-extras: lab
 
+        include:
           # this test is manually updated to reflect the lower bounds of
           # versions from dependencies
           - os: ubuntu-22.04
@@ -170,7 +171,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: |-
-            tests-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.pip-extras }}-${{ github.run_attempt }}
+            tests-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.pip-extras }}-${{ (matrix.pip-install-constraints != '' && 'oldest-') || '' }}${{ github.run_attempt }}
           path: |
             ./build/pytest
             ./build/coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,10 @@ classifiers = [
 dependencies = [
     "aiohttp",
     "importlib_metadata >=4.8.3 ; python_version<\"3.10\"",
-    "jupyter-server >=1.0",
-    "simpervisor >=1.0",
-    "tornado >=5.1",
-    "traitlets >= 4.2.1",
+    "jupyter-server >=1.24.0",
+    "simpervisor >=1.0.0",
+    "tornado >=6.1.0",
+    "traitlets >= 5.1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
It turns out our oldest dependency test never ran, it was listed under `exclude` rather than `include`.

When run, it failed. It was not possible to get it to install without pinning misc transient dependencies. I think though, that instead of doing that we should just require the latest jupyter-server 1 version (1.24.0), and that leads to requiring tornado 6.1 and traitlets 5.1. Those in turn have been required for a very long time.

I suggest we go for a merge of this without declaring it a breaking change.

- Fixes #466