### PR TITLE
feat: Allow Skipping of Activity Reporting

### DIFF
--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -157,6 +157,16 @@ One of:
 - A callable that takes any {ref}`callable arguments <server-process:callable-arguments>`,
   and returns a dictionary of strings that are used & treated same as above.
 
+### `skip_activity_reporting`
+
+Whether to report activity from the proxy to JupyterHub. If _True_, JupyterHub
+will not be notified of new activity.
+
+Useful if you want to have a seperate way of determining activity through a
+proxied application.
+
+Defaults to _False_.
+
 (server-process:callable-arguments)=
 
 #### Callable arguments

--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -160,7 +160,7 @@ One of:
 ### `update_last_activity`
 
 Whether to report activity from the proxy to Jupyter Server. If _True_, Jupyter Server
-will not be notified of new activity.
+will be notified of new activity. This is primarily used by JupyterHub for idle detection and culling.
 
 Useful if you want to have a seperate way of determining activity through a
 proxied application.

--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -157,15 +157,15 @@ One of:
 - A callable that takes any {ref}`callable arguments <server-process:callable-arguments>`,
   and returns a dictionary of strings that are used & treated same as above.
 
-### `skip_activity_reporting`
+### `update_last_activity`
 
-Whether to report activity from the proxy to JupyterHub. If _True_, JupyterHub
+Whether to report activity from the proxy to Jupyter Server. If _True_, Jupyter Server
 will not be notified of new activity.
 
 Useful if you want to have a seperate way of determining activity through a
 proxied application.
 
-Defaults to _False_.
+Defaults to _True_.
 
 (server-process:callable-arguments)=
 

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -1,6 +1,7 @@
 """
 Traitlets based configuration for jupyter_server_proxy
 """
+
 import sys
 from collections import namedtuple
 from warnings import warn
@@ -41,6 +42,7 @@ ServerProcess = namedtuple(
         "new_browser_tab",
         "request_headers_override",
         "rewrite_response",
+        "skip_activity_reporting",
     ],
 )
 
@@ -56,6 +58,7 @@ def _make_namedproxy_handler(sp: ServerProcess):
             self.unix_socket = sp.unix_socket
             self.mappath = sp.mappath
             self.rewrite_response = sp.rewrite_response
+            self.skip_activity_reporting = sp.skip_activity_reporting
 
         def get_request_headers_override(self):
             return self._realize_rendered_template(sp.request_headers_override)
@@ -80,6 +83,7 @@ def _make_supervisedproxy_handler(sp: ServerProcess):
             self.requested_unix_socket = sp.unix_socket
             self.mappath = sp.mappath
             self.rewrite_response = sp.rewrite_response
+            self.skip_activity_reporting = sp.skip_activity_reporting
 
         def get_env(self):
             return self._realize_rendered_template(sp.environment)
@@ -161,6 +165,9 @@ def make_server_process(name, server_process_config, serverproxy_config):
         rewrite_response=server_process_config.get(
             "rewrite_response",
             tuple(),
+        ),
+        skip_activity_reporting=server_process_config.get(
+            "skip_activity_reporting", False
         ),
     )
 
@@ -282,6 +289,9 @@ class ServerProxy(Configurable):
             instead of "dogs not allowed".
 
             Defaults to the empty tuple ``tuple()``.
+ 
+          skip_activity_reporting
+            Will cause the proxy to not report activity back to JupyterHub.
         """,
         config=True,
     )

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -42,7 +42,7 @@ ServerProcess = namedtuple(
         "new_browser_tab",
         "request_headers_override",
         "rewrite_response",
-        "skip_activity_reporting",
+        "update_last_activity",
     ],
 )
 
@@ -58,7 +58,7 @@ def _make_namedproxy_handler(sp: ServerProcess):
             self.unix_socket = sp.unix_socket
             self.mappath = sp.mappath
             self.rewrite_response = sp.rewrite_response
-            self.skip_activity_reporting = sp.skip_activity_reporting
+            self.update_last_activity = sp.update_last_activity
 
         def get_request_headers_override(self):
             return self._realize_rendered_template(sp.request_headers_override)
@@ -83,7 +83,7 @@ def _make_supervisedproxy_handler(sp: ServerProcess):
             self.requested_unix_socket = sp.unix_socket
             self.mappath = sp.mappath
             self.rewrite_response = sp.rewrite_response
-            self.skip_activity_reporting = sp.skip_activity_reporting
+            self.update_last_activity = sp.update_last_activity
 
         def get_env(self):
             return self._realize_rendered_template(sp.environment)
@@ -166,8 +166,8 @@ def make_server_process(name, server_process_config, serverproxy_config):
             "rewrite_response",
             tuple(),
         ),
-        skip_activity_reporting=server_process_config.get(
-            "skip_activity_reporting", False
+        update_last_activity=server_process_config.get(
+            "update_last_activity", True
         ),
     )
 
@@ -290,8 +290,8 @@ class ServerProxy(Configurable):
 
             Defaults to the empty tuple ``tuple()``.
  
-          skip_activity_reporting
-            Will cause the proxy to not report activity back to JupyterHub.
+          update_last_activity
+            Will cause the proxy to report activity back to jupyter server.
         """,
         config=True,
     )

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -117,7 +117,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             tuple(),
         )
         self._requested_subprotocols = None
-        self.skip_activity_reporting = kwargs.pop("skip_activity_reporting", False)
+        self.update_last_activity = kwargs.pop("update_last_activity", True)
         super().__init__(*args, **kwargs)
 
     # Support/use jupyter_server config arguments allow_origin and allow_origin_pat
@@ -235,7 +235,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         avoids proxied traffic being ignored by the notebook's
         internal idle-shutdown mechanism
         """
-        if not self.skip_activity_reporting:
+        if self.update_last_activity:
             self.settings["api_last_activity"] = utcnow()
 
     def _get_context_path(self, host, port):

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -117,6 +117,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             tuple(),
         )
         self._requested_subprotocols = None
+        self.skip_activity_reporting = kwargs.pop("skip_activity_reporting", False)
         super().__init__(*args, **kwargs)
 
     # Support/use jupyter_server config arguments allow_origin and allow_origin_pat
@@ -234,7 +235,8 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         avoids proxied traffic being ignored by the notebook's
         internal idle-shutdown mechanism
         """
-        self.settings["api_last_activity"] = utcnow()
+        if not self.skip_activity_reporting:
+            self.settings["api_last_activity"] = utcnow()
 
     def _get_context_path(self, host, port):
         """


### PR DESCRIPTION
Allows proxy to be configured if it reports back to JupyterHub. In some cases the proxy will always detect background activity which means that the pod will never get culled. In this case you must disable recording and use an alternative source of activity(outside of this MR).

Closes #471