### PR TITLE
feat: support stream api

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -54,7 +54,11 @@ def _make_proxy_handler(sp: ServerProcess):
     Create an appropriate handler with given parameters
     """
     if sp.command:
-        cls = SuperviseAndRawSocketHandler if sp.raw_socket_proxy else SuperviseAndProxyHandler
+        cls = (
+            SuperviseAndRawSocketHandler
+            if sp.raw_socket_proxy
+            else SuperviseAndProxyHandler
+        )
         args = dict(state={})
     elif not (sp.port or isinstance(sp.unix_socket, str)):
         warn(
@@ -122,13 +126,7 @@ def make_handlers(base_url, server_processes):
         handler = _make_proxy_handler(sp)
         if not handler:
             continue
-        handlers.append(
-            (
-                ujoin(base_url, sp.name, r"(.*)"),
-                handler,
-                handler.kwargs
-            )
-        )
+        handlers.append((ujoin(base_url, sp.name, r"(.*)"), handler, handler.kwargs))
         handlers.append((ujoin(base_url, sp.name), AddSlashHandler))
     return handlers
 
@@ -159,9 +157,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
             "rewrite_response",
             tuple(),
         ),
-        update_last_activity=server_process_config.get(
-            "update_last_activity", True
-        ),
+        update_last_activity=server_process_config.get("update_last_activity", True),
         raw_socket_proxy=server_process_config.get("raw_socket_proxy", False),
     )
 

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -4,7 +4,7 @@ Authenticated HTTP proxy for Jupyter Notebooks
 Some original inspiration from https://github.com/senko/tornado-proxy
 """
 
-import os
+import os, json, re
 import socket
 from asyncio import Lock
 from copy import copy
@@ -287,7 +287,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
 
         return client_uri
 
-    def _build_proxy_request(self, host, port, proxied_path, body):
+    def _build_proxy_request(self, host, port, proxied_path, body, **extra_opts):
         headers = self.proxy_request_headers()
 
         client_uri = self.get_client_uri("http", host, port, proxied_path)
@@ -307,6 +307,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             decompress_response=False,
             headers=headers,
             **self.proxy_request_options(),
+             **extra_opts,
         )
         return req
 
@@ -365,7 +366,82 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
                 body = b""
             else:
                 body = None
+        accept_type = self.request.headers.get('Accept')
+        if accept_type == 'text/event-stream':
+            return await self._proxy_progressive(host, port, proxied_path, body)
+        else:
+            return await self._proxy_normal(host, port, proxied_path, body)
+    
+    async def _proxy_progressive(self, host, port, proxied_path, body):
+        # Proxy in progressive flush mode, whenever chunks are received. Potentially slower but get results quicker for voila
 
+        client = httpclient.AsyncHTTPClient()
+
+        # Set up handlers so we can progressively flush result
+
+        headers_raw = []
+
+        def dump_headers(headers_raw):
+            for line in headers_raw:
+                r = re.match('^([a-zA-Z0-9\-_]+)\s*\:\s*([^\r\n]+)[\r\n]*$', line)
+                if r:
+                    k,v = r.groups([1,2])
+                    if k not in ('Content-Length', 'Transfer-Encoding',
+                                  'Content-Encoding', 'Connection'):
+                        # some header appear multiple times, eg 'Set-Cookie'
+                        self.set_header(k,v)
+                else:
+                    r = re.match('^HTTP[^\s]* ([0-9]+)', line)
+                    if r:
+                        status_code = r.group(1)
+                        self.set_status(int(status_code))
+            headers_raw.clear()
+
+        # clear tornado default header
+        self._headers = httputil.HTTPHeaders()
+
+        def header_callback(line):
+            headers_raw.append(line)
+
+        def streaming_callback(chunk):
+            # Do this here, not in header_callback so we can be sure headers are out of the way first
+            dump_headers(headers_raw) # array will be empty if this was already called before
+            self.write(chunk)
+            self.flush()
+
+        # Now make the request
+
+        req = self._build_proxy_request(host, port, proxied_path, body, 
+                    streaming_callback=streaming_callback, 
+                    header_callback=header_callback)
+
+        try:
+            response = await client.fetch(req, raise_error=False)
+        except httpclient.HTTPError as err:
+            if err.code == 599:
+                self._record_activity()
+                self.set_status(599)
+                self.write(str(err))
+                return
+            else:
+                raise
+
+        # record activity at start and end of requests
+        self._record_activity()
+
+        # For all non http errors...
+        if response.error and type(response.error) is not httpclient.HTTPError:
+            self.set_status(500)
+            self.write(str(response.error))
+        else:
+            self.set_status(response.code, response.reason) # Should already have been set
+
+            dump_headers(headers_raw) # Should already have been emptied
+
+            if response.body: # Likewise, should already be chunked out and flushed
+                self.write(response.body)
+
+    async def _proxy_normal(self, host, port, proxied_path, body):
         if self.unix_socket is not None:
             # Port points to a Unix domain socket
             self.log.debug("Making client for Unix socket %r", self.unix_socket)
@@ -457,6 +533,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
 
             if rewritten_response.body:
                 self.write(rewritten_response.body)
+
 
     async def proxy_open(self, host, port, proxied_path=""):
         """

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -374,7 +374,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
                 force_instance=True, resolver=UnixResolver(self.unix_socket)
             )
         else:
-            client = httpclient.AsyncHTTPClient()
+            client = httpclient.AsyncHTTPClient(force_instance=True)
         # check if the request is stream request
         accept_header = self.request.headers.get('Accept')
         if accept_header == 'text/event-stream':
@@ -425,7 +425,8 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
                     header_callback=header_callback)
         
         # no timeout for stream api
-        req.request_timeout = 0
+        req.request_timeout = 7200
+        req.connect_timeout = 600
         
         try:
             response = await client.fetch(req, raise_error=False)

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -376,8 +376,8 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         else:
             client = httpclient.AsyncHTTPClient()
         # check if the request is stream request
-        proxy_streaming = self.request.headers.get('Accept')
-        if proxy_streaming == 'text/event-stream':
+        accept_header = self.request.headers.get('Accept')
+        if accept_header == 'text/event-stream':
             return await self._proxy_progressive(host, port, proxied_path, body, client)
         else:
             return await self._proxy_buffered(host, port, proxied_path, body, client)

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -414,7 +414,10 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         req = self._build_proxy_request(host, port, proxied_path, body, 
                     streaming_callback=streaming_callback, 
                     header_callback=header_callback)
-
+        
+        # no timeout for stream api
+        req.request_timeout = 0
+        
         try:
             response = await client.fetch(req, raise_error=False)
         except httpclient.HTTPError as err:

--- a/tests/resources/eventstream.py
+++ b/tests/resources/eventstream.py
@@ -1,0 +1,36 @@
+import asyncio
+
+import tornado.escape
+import tornado.ioloop
+import tornado.options
+import tornado.web
+import tornado.websocket
+from tornado.options import define, options
+
+
+class Application(tornado.web.Application):
+    def __init__(self):
+        handlers = [
+            (r"/stream/(\d+)", StreamHandler),
+        ]
+        super().__init__(handlers)
+
+
+class StreamHandler(tornado.web.RequestHandler):
+    async def get(self, seconds):
+        for i in range(int(seconds)):
+            await asyncio.sleep(0.5)
+            self.write(f"data: {i}\n\n")
+            await self.flush()
+
+
+def main():
+    define("port", default=8888, help="run on the given port", type=int)
+    options.parse_command_line()
+    app = Application()
+    app.listen(options.port)
+    tornado.ioloop.IOLoop.current().start()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -79,6 +79,9 @@ c.ServerProxy.servers = {
             "X-Custom-Header": "pytest-23456",
         },
     },
+    "python-eventstream": {
+        "command": [sys.executable, "./tests/resources/eventstream.py", "--port={port}"]
+    },
     "python-unix-socket-true": {
         "command": [
             sys.executable,

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -42,10 +42,10 @@ def cats_only(response, path):
         response.code = 403
         response.body = b"dogs not allowed"
 
+
 def my_env():
-    return {
-            "MYVAR": "String with escaped {{var}}"
-        }
+    return {"MYVAR": "String with escaped {{var}}"}
+
 
 c.ServerProxy.servers = {
     "python-http": {

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -132,12 +132,12 @@ c.ServerProxy.servers = {
     "python-proxyto54321-no-command": {"port": 54321},
     "python-rawsocket-tcp": {
         "command": [sys.executable, "./tests/resources/rawsocket.py", "{port}"],
-        "raw_socket_proxy": True
+        "raw_socket_proxy": True,
     },
     "python-rawsocket-unix": {
         "command": [sys.executable, "./tests/resources/rawsocket.py", "{unix_socket}"],
         "unix_socket": True,
-        "raw_socket_proxy": True
+        "raw_socket_proxy": True,
     },
 }
 

--- a/tests/resources/rawsocket.py
+++ b/tests/resources/rawsocket.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import os
 import socket
 import sys
 
@@ -11,7 +10,7 @@ where = sys.argv[1]
 try:
     port = int(where)
     family = socket.AF_INET
-    addr = ('localhost', port)
+    addr = ("localhost", port)
 except ValueError:
     family = socket.AF_UNIX
     addr = where

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -378,7 +378,7 @@ async def test_eventstream(a_server_port_and_token: Tuple[int, str]) -> None:
     print(stream_read_intervals)
     assert all([0.45 < t < 3.0 for t in stream_read_intervals])
     print(stream_data)
-    assert stream_data == ['data: 1\n\n','data: 2\n\n','data: 3\n\n']
+    assert stream_data == [b'data: 0\n\n', b'data: 1\n\n', b'data: 2\n\n']
 
 
 async def test_server_proxy_websocket_messages(

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -506,18 +506,20 @@ def test_callable_environment_formatting(
     assert r.code == 200
 
 
-@pytest.mark.parametrize("rawsocket_type", [
-    "tcp",
-    pytest.param(
-        "unix",
-        marks=pytest.mark.skipif(
-            sys.platform == "win32", reason="Unix socket not supported on Windows"
+@pytest.mark.parametrize(
+    "rawsocket_type",
+    [
+        "tcp",
+        pytest.param(
+            "unix",
+            marks=pytest.mark.skipif(
+                sys.platform == "win32", reason="Unix socket not supported on Windows"
+            ),
         ),
-    ),
-])
+    ],
+)
 async def test_server_proxy_rawsocket(
-    rawsocket_type: str,
-    a_server_port_and_token: Tuple[int, str]
+    rawsocket_type: str, a_server_port_and_token: Tuple[int, str]
 ) -> None:
     PORT, TOKEN = a_server_port_and_token
     url = f"ws://{LOCALHOST}:{PORT}/python-rawsocket-{rawsocket_type}/?token={TOKEN}"

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -371,13 +371,10 @@ async def test_eventstream(a_server_port_and_token: Tuple[int, str]) -> None:
     await client.fetch(
         url,
         headers={"Accept": "text/event-stream"},
-        request_timeout=22,
         streaming_callback=streaming_cb,
     )
     assert times_called == limit
-    print(stream_read_intervals)
     assert all([0.45 < t < 3.0 for t in stream_read_intervals])
-    print(stream_data)
     assert stream_data == [b'data: 0\n\n', b'data: 1\n\n', b'data: 2\n\n']
 
 

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -374,7 +374,7 @@ async def test_eventstream(a_server_port_and_token: Tuple[int, str]) -> None:
     )
     assert times_called == limit
     print(stream_read_intervals)
-    assert all([0.45 < t < 0.9 for t in stream_read_intervals])
+    assert all([0.45 < t < 3.0 for t in stream_read_intervals])
 
 
 async def test_server_proxy_websocket_messages(

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -356,6 +356,7 @@ async def test_eventstream(a_server_port_and_token: Tuple[int, str]) -> None:
     last_cb_time = time.perf_counter()
     times_called = 0
     stream_read_intervals = []
+    stream_data = []
 
     def streaming_cb(data):
         nonlocal times_called, last_cb_time, stream_read_intervals
@@ -363,6 +364,7 @@ async def test_eventstream(a_server_port_and_token: Tuple[int, str]) -> None:
         last_cb_time = time.perf_counter()
         stream_read_intervals.append(time_taken)
         times_called += 1
+        stream_data.append(data)
 
     url = f"http://{LOCALHOST}:{PORT}/python-eventstream/stream/{limit}?token={TOKEN}"
     client = AsyncHTTPClient()
@@ -375,6 +377,8 @@ async def test_eventstream(a_server_port_and_token: Tuple[int, str]) -> None:
     assert times_called == limit
     print(stream_read_intervals)
     assert all([0.45 < t < 3.0 for t in stream_read_intervals])
+    print(stream_data)
+    assert stream_data == ['data: 1\n\n','data: 2\n\n','data: 3\n\n']
 
 
 async def test_server_proxy_websocket_messages(

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -375,7 +375,7 @@ async def test_eventstream(a_server_port_and_token: Tuple[int, str]) -> None:
     )
     assert times_called == limit
     assert all([0.45 < t < 3.0 for t in stream_read_intervals])
-    assert stream_data == [b'data: 0\n\n', b'data: 1\n\n', b'data: 2\n\n']
+    assert stream_data == [b"data: 0\n\n", b"data: 1\n\n", b"data: 2\n\n"]
 
 
 async def test_server_proxy_websocket_messages(

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -374,7 +374,7 @@ async def test_eventstream(a_server_port_and_token: Tuple[int, str]) -> None:
     )
     assert times_called == limit
     print(stream_read_intervals)
-    assert all([0.45 < t < 0.7 for t in stream_read_intervals])
+    assert all([0.45 < t < 0.9 for t in stream_read_intervals])
 
 
 async def test_server_proxy_websocket_messages(


### PR DESCRIPTION
currently jupyter-server-proxy does not support the text/event-stream api. when we install https://github.com/hiyouga/LLaMA-Factory in the notebook instance, and access by : http://xxx.xxx/proxy/7860/
the normal request works fine, but the stream API never response.
reference code: https://github.com/ideonate/jhsingle-native-proxy/blob/3e26a4ee0e7318970b7cf6abbd7d88455a9ac621/jhsingle_native_proxy/proxyhandlers.py#L217




