### PR TITLE
Fix failure to update __version__

### DIFF
--- a/jupyter_server_proxy/_version.py
+++ b/jupyter_server_proxy/_version.py
@@ -1,4 +1,4 @@
 # __version__ should be updated using tbump, based on configuration in
 # pyproject.toml, according to instructions in RELEASE.md.
 #
-__version__ = "4.1.1-0.dev"
+__version__ = "4.2.1-0.dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,9 @@ message_template = "Bump to {new_version}"
 tag_template = "v{new_version}"
 
 [[tool.tbump.file]]
+src = "jupyter_server_proxy/_version.py"
+
+[[tool.tbump.file]]
 src = "pyproject.toml"
 
 [[tool.tbump.file]]


### PR DESCRIPTION
During our release process, the `_version.py` file wasn't updated as it should been so when inspecting `__version__` we actually just got `4.1.1-0.dev` in the released package where we expected `4.2.0`.