### PR TITLE
ci: fix test failure on windows and error on bash pipe failures etc

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        shell: bash # windows default isn't bash
+        shell: bash --noprofile --norc -eo pipefail {0} # windows default isn't bash
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -119,7 +119,7 @@ jobs:
           python-version: "${{ matrix.python-version }}"
 
       - name: Update root build packages
-        run: pip install --upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Download built artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Fixes #482 and ensures that we error on pipe failures etc.