### PR TITLE
Remove utils.Callable

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -12,18 +12,11 @@ else:  # pragma: no cover
     from importlib.metadata import entry_points
 
 from jupyter_server.utils import url_path_join as ujoin
-from traitlets import Dict, List, Tuple, Union, default, observe
+from traitlets import Callable, Dict, List, Tuple, Union, default, observe
 from traitlets.config import Configurable
 
 from .handlers import AddSlashHandler, NamedLocalProxyHandler, SuperviseAndProxyHandler
 from .rawsocket import RawSocketHandler, SuperviseAndRawSocketHandler
-
-try:
-    # Traitlets >= 4.3.3
-    from traitlets import Callable
-except ImportError:
-    from .utils import Callable
-
 
 LauncherEntry = namedtuple(
     "LauncherEntry", ["enabled", "icon_path", "title", "path_info", "category"]

--- a/jupyter_server_proxy/utils.py
+++ b/jupyter_server_proxy/utils.py
@@ -1,6 +1,3 @@
-from traitlets import TraitType
-
-
 def call_with_asked_args(callback, args):
     """
     Call callback with only the args it wants from args
@@ -31,21 +28,3 @@ def call_with_asked_args(callback, args):
             )
         )
     return callback(*asked_arg_values)
-
-
-# copy-pasted from the ipython/traitlets source code, see
-# https://github.com/ipython/traitlets/blob/a1425327460c4a3ae970aeaef17e0c22da4c53c6/traitlets/traitlets.py#L3232-L3246
-class Callable(TraitType):
-    """A trait which is callable.
-    Notes
-    -----
-    Classes are callable, as are instances
-    with a __call__() method."""
-
-    info_text = "a callable"
-
-    def validate(self, obj, value):
-        if callable(value):
-            return value
-        else:
-            self.error(obj, value)


### PR DESCRIPTION
This was for compatibility with older versions of Traitlets, but we already require 5.1.0 https://github.com/jupyterhub/jupyter-server-proxy/blob/3d0eac577ae9ad768252b1a091ae6113ebc5f3ba/pyproject.toml#L50