### PR TITLE
Enable progressive proxy via flag

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -151,7 +151,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
             "rewrite_response",
             tuple(),
         ),
-        progressive=server_process_config.get("progressive", False),
+        progressive=server_process_config.get("progressive", None),
         update_last_activity=server_process_config.get("update_last_activity", True),
         raw_socket_proxy=server_process_config.get("raw_socket_proxy", False),
     )
@@ -280,9 +280,15 @@ class ServerProxy(Configurable):
             Useful for applications streaming their data, where the buffering of requests can lead
             to a lagging, e.g. in video streams.
             
-            Must be either a bool, when all requests are supposed to be progressive, or a function
-            taking the "Accept" header of the request as input and returning a bool, whether this request
-            should be made progressive.
+            Must be either None (default), a bool, or a function. Setting it to a boolean will enable/disable 
+            progressive requests for all types. Setting to None, jupyter-server-proxy will only enable progressive 
+            for somespecial types, like videos, images and binary data. A function must be taking the "Accept" header of
+            the request from the client as input and returning a bool, whether this request should be made progressive.
+            
+            Note: `progressive` and `rewrite_response` are mutually exclusive on the same request. When rewrite_response
+            is given and progressive is None, the proxying will never be progressive. If progressive is a function,
+            rewrite_response will only be called on requests where it returns False. Progressive takes precedence over
+            rewrite_response when both are given!
  
           update_last_activity
             Will cause the proxy to report activity back to jupyter server.

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -36,6 +36,7 @@ ServerProcess = namedtuple(
         "new_browser_tab",
         "request_headers_override",
         "rewrite_response",
+        "progressive",
         "update_last_activity",
         "raw_socket_proxy",
     ],
@@ -150,6 +151,7 @@ def make_server_process(name, server_process_config, serverproxy_config):
             "rewrite_response",
             tuple(),
         ),
+        progressive=server_process_config.get("progressive", False),
         update_last_activity=server_process_config.get("update_last_activity", True),
         raw_socket_proxy=server_process_config.get("raw_socket_proxy", False),
     )
@@ -272,6 +274,15 @@ class ServerProxy(Configurable):
             instead of "dogs not allowed".
 
             Defaults to the empty tuple ``tuple()``.
+            
+          progressive
+            Makes the proxy progressive, meaning it won't buffer any requests from the server.
+            Useful for applications streaming their data, where the buffering of requests can lead
+            to a lagging, e.g. in video streams.
+            
+            Must be either a bool, when all requests are supposed to be progressive, or a function
+            taking the "Accept" header of the request as input and returning a bool, whether this request
+            should be made progressive.
  
           update_last_activity
             Will cause the proxy to report activity back to jupyter server.

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -22,7 +22,7 @@ from traitlets import Bytes, Dict, Instance, Integer, Unicode, Union, default, o
 from traitlets.traitlets import HasTraits
 
 from .unixsock import UnixResolver
-from .utils import call_with_asked_args
+from .utils import call_with_asked_args, mime_types_match
 from .websocket import WebSocketHandlerMixin, pingable_ws_connect
 
 
@@ -95,6 +95,14 @@ class AddSlashHandler(JupyterHandler):
         self.redirect(urlunparse(dest))
 
 
+COMMON_BINARY_MIME_TYPES = [
+    "image/*" "audio/*",
+    "video/*",
+    "application/*",
+    "text/event-stream",
+]
+
+
 class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
     """
     A tornado request handler that proxies HTTP and websockets from
@@ -117,9 +125,36 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             "rewrite_response",
             tuple(),
         )
+        self.progressive = kwargs.pop("progressive", False)
         self._requested_subprotocols = None
         self.update_last_activity = kwargs.pop("update_last_activity", True)
         super().__init__(*args, **kwargs)
+
+    @property
+    def progressive(self):
+        accept_header = self.request.headers.get("Accept")
+
+        if self._progressive:
+            if callable(self._progressive):
+                return self._progressive(accept_header)
+            else:
+                return True
+
+        # Progressive and RewritableResponse are mutually exclusive
+        if self.rewrite_response:
+            return False
+
+        if accept_header is None:
+            return False
+
+        return any(
+            mime_types_match(pattern, accept_header)
+            for pattern in COMMON_BINARY_MIME_TYPES
+        )
+
+    @progressive.setter
+    def progressive(self, value):
+        self._progressive = value
 
     # Support/use jupyter_server config arguments allow_origin and allow_origin_pat
     # to enable cross origin requests propagated by e.g. inverting proxies.
@@ -376,9 +411,8 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             )
         else:
             client = httpclient.AsyncHTTPClient(force_instance=True)
-        # check if the request is stream request
-        accept_header = self.request.headers.get("Accept")
-        if accept_header == "text/event-stream":
+
+        if self.progressive:
             return await self._proxy_progressive(host, port, proxied_path, body, client)
         else:
             return await self._proxy_buffered(host, port, proxied_path, body, client)

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -96,7 +96,8 @@ class AddSlashHandler(JupyterHandler):
 
 
 COMMON_BINARY_MIME_TYPES = [
-    "image/*" "audio/*",
+    "image/*",
+    "audio/*",
     "video/*",
     "application/*",
     "text/event-stream",
@@ -125,7 +126,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
             "rewrite_response",
             tuple(),
         )
-        self.progressive = kwargs.pop("progressive", False)
+        self.progressive = kwargs.pop("progressive", None)
         self._requested_subprotocols = None
         self.update_last_activity = kwargs.pop("update_last_activity", True)
         super().__init__(*args, **kwargs)
@@ -134,17 +135,21 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
     def progressive(self):
         accept_header = self.request.headers.get("Accept")
 
-        if self._progressive:
+        if self._progressive is not None:
             if callable(self._progressive):
                 return self._progressive(accept_header)
             else:
-                return True
+                return self._progressive
 
         # Progressive and RewritableResponse are mutually exclusive
         if self.rewrite_response:
             return False
 
         if accept_header is None:
+            return False
+
+        # If the client can accept multiple types, we will not make the request progressive
+        if "," in accept_header.split(";")[0]:
             return False
 
         return any(

--- a/jupyter_server_proxy/utils.py
+++ b/jupyter_server_proxy/utils.py
@@ -28,3 +28,20 @@ def call_with_asked_args(callback, args):
             )
         )
     return callback(*asked_arg_values)
+
+
+def mime_types_match(pattern: str, value: str) -> bool:
+    """
+    Compare a MIME type pattern, possibly with wildcards, and a value
+    """
+    value = value.split(";")[0]  # Remove optional details
+    if pattern == value:
+        return True
+
+    type, subtype = value.split("/")
+    pattern = pattern.split("/")
+
+    if pattern[0] == "*" or (pattern[0] == type and pattern[1] == "*"):
+        return True
+
+    return False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,3 +7,28 @@ def test_call_with_asked_args():
         return c
 
     assert utils.call_with_asked_args(_test_func, {"a": 5, "b": 4, "c": 8}) == 20
+
+
+def test_mime_types_match():
+    # Exact match
+    assert utils.mime_types_match("text/plain", "text/plain")
+    assert not utils.mime_types_match("text/plain", "text/html")
+
+    # With optional parameters
+    assert utils.mime_types_match("text/plain", "text/plain;charset=UTF-8")
+    assert not utils.mime_types_match("text/plain", "text/html;charset=UTF-8")
+
+    # With a single widcard
+    assert utils.mime_types_match("*", "text/plain")
+    assert utils.mime_types_match("*", "text/plain;charset=UTF-8")
+
+    # With both components wildcard
+    assert utils.mime_types_match("*/*", "text/plain")
+    assert utils.mime_types_match("*/*", "text/plain;charset=UTF-8")
+
+    # With a subtype wildcard
+    assert utils.mime_types_match("text/*", "text/plain")
+    assert not utils.mime_types_match("image/*", "text/plain")
+
+    assert utils.mime_types_match("text/*", "text/plain;charset=UTF-8")
+    assert not utils.mime_types_match("image/*", "text/plain;charset=UTF-8")


### PR DESCRIPTION
With the current implementation for progressive proxies from #479, we only make the request progressive if the Accept Header of the request is exactly `text/event-stream`. We would like to use this feature with other proxies, where the Mime-Type is not so directly determinable, like with *xpra* (Remote Destop).
As far as I can tell, there is no particular reason to limit the progressive feature to only this use case (see #502).

I changed the code to instead allow configuring the behavior of the proxy via the entrypoint of a proxy. The dictionary returned by the entry point can now contain a value "progressive". When set to either `True` or `False`, we can explicitly enable or disable the progressive proxying. When left empty, we will automatically determine what type of proxy to use (see the `progressive` property).
It can also be a function, when the developer wants to dynamically switch between progressive and buffered proxying.

Note: Merging this will collide with #507 & #508 (and possibly #501)!