### PR TITLE
Make ServerProcess and LauncherEntry a HasTraits

### DIFF
--- a/docs/source/standalone.md
+++ b/docs/source/standalone.md
@@ -51,7 +51,7 @@ jupyter standaloneproxy --address=localhost --port=8000 ...
 
 ### Disable Authentication
 
-For testing, it can be useful to disable the authentication with JupyterHub. Passing `--skip-authentication` will
+For testing, it can be useful to disable the authentication with JupyterHub. Passing `--no-authentication` will
 not trigger the login process when accessing the application.
 
 ```{warning} Disabling authentication will leave the application open to anyone! Be careful with it,
@@ -76,7 +76,7 @@ c.StandaloneProxyServer.address = "localhost"
 c.StandaloneProxyServer.port = 8000
 
 # Disable authentication
-c.StandaloneProxyServer.skip_authentication = True
+c.StandaloneProxyServer.no_authentication = True
 ```
 
 A default config file can be emitted by running `jupyter standaloneproxy --generate-config`

--- a/jupyter_server_proxy/__init__.py
+++ b/jupyter_server_proxy/__init__.py
@@ -3,7 +3,7 @@ from jupyter_server.utils import url_path_join as ujoin
 from ._version import __version__  # noqa
 from .api import IconHandler, ServersInfoHandler
 from .config import ServerProxy as ServerProxyConfig
-from .config import get_entrypoint_server_processes, make_handlers, make_server_process
+from .config import get_entrypoint_server_processes, make_handlers
 from .handlers import setup_handlers
 
 
@@ -41,11 +41,8 @@ def _load_jupyter_server_extension(nbapp):
     base_url = nbapp.web_app.settings["base_url"]
     serverproxy_config = ServerProxyConfig(parent=nbapp)
 
-    server_processes = [
-        make_server_process(name, server_process_config, serverproxy_config)
-        for name, server_process_config in serverproxy_config.servers.items()
-    ]
-    server_processes += get_entrypoint_server_processes(serverproxy_config)
+    server_processes = list(serverproxy_config.servers.values())
+    server_processes += get_entrypoint_server_processes()
     server_handlers = make_handlers(base_url, server_processes)
     nbapp.web_app.add_handlers(".*", server_handlers)
 

--- a/jupyter_server_proxy/standalone/proxy.py
+++ b/jupyter_server_proxy/standalone/proxy.py
@@ -32,7 +32,7 @@ def make_standalone_proxy(
             super().__init__(*args, **kwargs)
             self.environment = {}
             self.timeout = 60
-            self.skip_authentication = False
+            self.no_authentication = False
 
         @property
         def log(self) -> Logger:
@@ -69,7 +69,7 @@ def make_standalone_proxy(
             return RequestHandler.write_error(self, status_code, **kwargs)
 
         async def proxy(self, port, path):
-            if self.skip_authentication:
+            if self.no_authentication:
                 return await super().proxy(port, path)
             else:
                 return await ensure_async(self.oauth_proxy(port, path))

--- a/tests/test_standalone.py
+++ b/tests/test_standalone.py
@@ -40,7 +40,7 @@ class _TestStandaloneBase(testing.AsyncHTTPTestCase):
     runTest = None  # Required for Tornado 6.1
 
     unix_socket: bool
-    skip_authentication: bool
+    no_authentication: bool
 
     def get_app(self):
         command = [
@@ -55,7 +55,7 @@ class _TestStandaloneBase(testing.AsyncHTTPTestCase):
             base_url="/some/prefix",
             unix_socket=self.unix_socket,
             timeout=60,
-            skip_authentication=self.skip_authentication,
+            no_authentication=self.no_authentication,
             log_level=logging.DEBUG,
         )
 
@@ -69,7 +69,7 @@ class TestStandaloneProxyRedirect(_TestStandaloneBase):
     """
 
     unix_socket = False
-    skip_authentication = True
+    no_authentication = True
 
     def test_add_slash(self):
         response = self.fetch("/some/prefix", follow_redirects=False)
@@ -97,7 +97,7 @@ class TestStandaloneProxyRedirect(_TestStandaloneBase):
 )
 class TestStandaloneProxyWithUnixSocket(_TestStandaloneBase):
     unix_socket = True
-    skip_authentication = True
+    no_authentication = True
 
     def test_with_unix_socket(self):
         response = self.fetch("/some/prefix/")
@@ -115,7 +115,7 @@ class TestStandaloneProxyLogin(_TestStandaloneBase):
     """
 
     unix_socket = False
-    skip_authentication = False
+    no_authentication = False
 
     def test_redirect_to_login_url(self):
         response = self.fetch("/some/prefix/", follow_redirects=False)


### PR DESCRIPTION
As I have mentioned in #507 and #501, I do not think there is a good reason to make `ServerProcess` and `LauncherIcon` a `Configurable`. I like the new approach of using traitlets for these two, but `ServerProxy` is already a Configurable, so I think we should be fine when downgrading them to a `HasTraits`.

I also allowed the entries of `ServerProxy.servers` to be an instance of `ServerProcess`, so users can now do `ServerProxy.servers[name] = ServerProxy(command=[...], ...)` instead of using a dictionary.