### PR TITLE
Wrong path_info generation in LauncherEntry

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -63,10 +63,6 @@ class LauncherEntry(Configurable):
     """,
     )
 
-    @default("path_info")
-    def _default_path_info(self):
-        return self.title + "/"
-
     category = Unicode(
         "Notebook",
         help="""
@@ -179,13 +175,13 @@ class ServerProcess(Configurable):
 
     @validate("launcher_entry")
     def _validate_launcher_entry(self, proposal):
-        kwargs = {"title": self.name}
+        kwargs = {"title": self.name, "path_info": self.name + "/"}
         kwargs.update(proposal["value"])
         return LauncherEntry(**kwargs)
 
     @default("launcher_entry")
     def _default_launcher_entry(self):
-        return LauncherEntry(title=self.name)
+        return LauncherEntry(title=self.name, path_info=self.name + "/")
 
     new_browser_tab = Bool(
         True,


### PR DESCRIPTION
When a ServerProcess/Entrypoint provides an explicit title for the LauncherEntry, the path to the application is generated incorrectly.
We encountered this with the [RStudio Proxy](https://github.com/jupyterhub/jupyter-rsession-proxy/blob/main/jupyter_rsession_proxy/__init__.py#L210), which sets `"title": "RStudio"` in the entrypoint. When you click on the icon, you will be redirected to `.../RStudio/` instead of `.../rstudio/`, which will result in a 404. The name of the ServerProcess is `rstudio` and the listener registered on `/rstudio/`