### PR TITLE
Make ServerProcess.timeout a Float

### DIFF
--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -16,6 +16,7 @@ from traitlets import (
     Bool,
     Callable,
     Dict,
+    Float,
     Instance,
     Int,
     List,
@@ -106,8 +107,8 @@ class ServerProcess(Configurable):
     """,
     ).tag(config=True)
 
-    timeout = Int(
-        5, help="Timeout in seconds for the process to become ready, default 5s."
+    timeout = Float(
+        5.0, help="Timeout in seconds for the process to become ready, default 5s."
     ).tag(config=True)
 
     absolute_url = Bool(


### PR DESCRIPTION
simpervisor accepts a float as the timeout (see [here](https://github.com/jupyterhub/simpervisor/blob/main/simpervisor/process.py#L322)), while we currently only accept an int in the traitlets.

Used e.g. in the [RStudio Proxy](https://github.com/jupyterhub/jupyter-rsession-proxy/blob/main/jupyter_rsession_proxy/__init__.py#L142).