### PR TITLE
Fix websocket requests not mapped via mappath

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -16,7 +16,7 @@ import aiohttp
 from jupyter_server.base.handlers import JupyterHandler, utcnow
 from jupyter_server.utils import ensure_async, url_path_join
 from simpervisor import SupervisedProcess
-from tornado import httpclient, httputil, web, websocket
+from tornado import httpclient, httputil, web
 from tornado.simple_httpclient import SimpleAsyncHTTPClient
 from traitlets import Bytes, Dict, Instance, Integer, Unicode, Union, default, observe
 from traitlets.traitlets import HasTraits
@@ -171,7 +171,7 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         raise NotImplementedError(
             "Subclasses of ProxyHandler should implement http_get"
         )
-    
+
     async def get(self, *args, **kwargs):
         return await self.http_get(*args, **kwargs)
 
@@ -338,7 +338,10 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
 
         self._record_activity()
 
-        if self.request.method == "GET" and self.request.headers.get("Upgrade", "").lower() == "websocket":
+        if (
+            self.request.method == "GET"
+            and self.request.headers.get("Upgrade", "").lower() == "websocket"
+        ):
             return await ensure_async(self.get_websocket(proxied_path))
 
         # Remove hop-by-hop headers that don't necessarily apply to the request we are making

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -16,7 +16,7 @@ import aiohttp
 from jupyter_server.base.handlers import JupyterHandler, utcnow
 from jupyter_server.utils import ensure_async, url_path_join
 from simpervisor import SupervisedProcess
-from tornado import httpclient, httputil, web
+from tornado import httpclient, httputil, web, websocket
 from tornado.simple_httpclient import SimpleAsyncHTTPClient
 from traitlets import Bytes, Dict, Instance, Integer, Unicode, Union, default, observe
 from traitlets.traitlets import HasTraits
@@ -171,6 +171,9 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         raise NotImplementedError(
             "Subclasses of ProxyHandler should implement http_get"
         )
+    
+    async def get(self, *args, **kwargs):
+        return await self.http_get(*args, **kwargs)
 
     def post(self, host, port, proxy_path=""):
         raise NotImplementedError(
@@ -333,6 +336,11 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
                 "See https://jupyter-server-proxy.readthedocs.io/en/latest/arbitrary-ports-hosts.html for info.",
             )
 
+        self._record_activity()
+
+        if self.request.method == "GET" and self.request.headers.get("Upgrade", "").lower() == "websocket":
+            return await ensure_async(self.get_websocket(proxied_path))
+
         # Remove hop-by-hop headers that don't necessarily apply to the request we are making
         # to the backend. See https://github.com/jupyterhub/jupyter-server-proxy/pull/328
         # for more information
@@ -350,16 +358,6 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         for header_to_remove in hop_by_hop_headers:
             if header_to_remove in self.request.headers:
                 del self.request.headers[header_to_remove]
-
-        self._record_activity()
-
-        if self.request.headers.get("Upgrade", "").lower() == "websocket":
-            # We wanna websocket!
-            # jupyterhub/jupyter-server-proxy@36b3214
-            self.log.info(
-                "we wanna websocket, but we don't define WebSocketProxyHandler"
-            )
-            self.set_status(500)
 
         body = self.request.body
         if not body:

--- a/jupyter_server_proxy/rawsocket.py
+++ b/jupyter_server_proxy/rawsocket.py
@@ -55,6 +55,12 @@ class RawSocketHandler(NamedLocalProxyHandler):
             return loop.create_connection(proto, "localhost", self.port)
 
     async def proxy(self, port, path):
+        if (
+            self.request.method == "GET"
+            and self.request.headers.get("Upgrade", "").lower() == "websocket"
+        ):
+            return await super().proxy(port, path)
+        
         raise web.HTTPError(
             405, "this raw_socket_proxy backend only supports websocket connections"
         )

--- a/jupyter_server_proxy/rawsocket.py
+++ b/jupyter_server_proxy/rawsocket.py
@@ -60,7 +60,7 @@ class RawSocketHandler(NamedLocalProxyHandler):
             and self.request.headers.get("Upgrade", "").lower() == "websocket"
         ):
             return await super().proxy(port, path)
-        
+
         raise web.HTTPError(
             405, "this raw_socket_proxy backend only supports websocket connections"
         )

--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -96,8 +96,5 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
             setattr(self, method, wrapper(method))
         nextparent.__init__(self, *args, **kwargs)
 
-    async def get(self, *args, **kwargs):
-        if self.request.headers.get("Upgrade", "").lower() != "websocket":
-            return await self.http_get(*args, **kwargs)
-        else:
-            await ensure_async(super().get(*args, **kwargs))
+    async def get_websocket(self, *args, **kwargs):
+        await ensure_async(super().get(*args, **kwargs))

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -17,6 +17,7 @@ def mappathf(path):
     p = path + "mapped"
     return p
 
+
 def mappathf_socket(path):
     return path + "socket"
 

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -17,6 +17,9 @@ def mappathf(path):
     p = path + "mapped"
     return p
 
+def mappathf_socket(path):
+    return path + "socket"
+
 
 def translate_ciao(path, host, response, orig_response, port):
     # Assume that the body has not been modified by any previous rewrite
@@ -82,6 +85,10 @@ c.ServerProxy.servers = {
         "request_headers_override": {
             "X-Custom-Header": "pytest-23456",
         },
+    },
+    "python-websocket-mappathf_socket": {
+        "command": [sys.executable, _get_path("websocket.py"), "--port={port}"],
+        "mappath": mappathf_socket,
     },
     "python-eventstream": {
         "command": [sys.executable, _get_path("eventstream.py"), "--port={port}"]

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -401,6 +401,19 @@ async def test_server_proxy_websocket_headers(a_server_port_and_token: Tuple[int
     assert headers["X-Custom-Header"] == "pytest-23456"
 
 
+async def test_server_proxy_websocket_messages_mappath(
+    a_server_port_and_token: Tuple[int, str]
+) -> None:
+    PORT, TOKEN = a_server_port_and_token
+    # Mappath is configured to add "socket" to websocket paths
+    url = f"ws://{LOCALHOST}:{PORT}/python-websocket-mappathf_socket/echo?token={TOKEN}"
+    conn = await websocket_connect(url)
+    expected_msg = "Hello, world!"
+    await conn.write_message(expected_msg)
+    msg = await conn.read_message()
+    assert msg == expected_msg
+
+
 @pytest.mark.parametrize(
     "client_requested,server_received,server_responded,proxy_responded",
     [


### PR DESCRIPTION
This is done by instead of WebSocketHandlerMixin providing the default `get` method and delegating to `ProxyHandler.http_get`, it now provides `get_websocket` and `ProxyHandler.proxy` delegates to it.

Code is also removed that was never reached since it checked for the "Upgrade" HTTP header after removing it among others defined in `hop_by_hop_headers`.

Fixes #525