### PR TITLE
Add icon type description for the `icon_path` property under ServerProxy.servers

### DIFF
--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -123,7 +123,7 @@ the following keys:
    explicit entry.
 2. **icon_path**
    Full path to an svg icon that could be used with a launcher. Currently only used by the
-   JupyterLab launcher, when category is "Notebook" (default) or "Console". Only text-based icon 
+   JupyterLab launcher, when category is "Notebook" (default) or "Console". Only text-based icon
    formats, such as SVG, are supported. Using binary-based formats like PNG or JPEG will
    result in an empty icon being displayed in kernels.
 3. **title**

--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -123,13 +123,15 @@ the following keys:
    explicit entry.
 2. **icon_path**
    Full path to an svg icon that could be used with a launcher. Currently only used by the
-   JupyterLab launcher, when category is "Notebook" (default) or "Console".
-3. **title**
+   JupyterLab launcher, when category is "Notebook" (default) or "Console". Only text-based icon 
+   formats, such as SVG, are supported. Using binary-based formats like PNG or JPEG will
+   result in an empty icon being displayed in kernels.
+4. **title**
    Title to be used for the launcher entry. Defaults to the name of the server if missing.
-4. **path_info**
+5. **path_info**
    The trailing path that is appended to the user's server URL to access the proxied server.
    By default it is the name of the server followed by a trailing slash.
-5. **category**
+6. **category**
    The category for the launcher item. Currently only used by the JupyterLab launcher.
    By default it is "Notebook".
 

--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -126,12 +126,12 @@ the following keys:
    JupyterLab launcher, when category is "Notebook" (default) or "Console". Only text-based icon 
    formats, such as SVG, are supported. Using binary-based formats like PNG or JPEG will
    result in an empty icon being displayed in kernels.
-4. **title**
+3. **title**
    Title to be used for the launcher entry. Defaults to the name of the server if missing.
-5. **path_info**
+4. **path_info**
    The trailing path that is appended to the user's server URL to access the proxied server.
    By default it is the name of the server followed by a trailing slash.
-6. **category**
+5. **category**
    The category for the launcher item. Currently only used by the JupyterLab launcher.
    By default it is "Notebook".
 


### PR DESCRIPTION
in `IconHandler`
https://github.com/jupyterhub/jupyter-server-proxy/blob/8c5906a68f90252951342ccd626e0332f8531872/jupyter_server_proxy/api.py#L71

Reading the icon file is under text (not binary) mode, thus only text-based icon types are supported
by the `icon_path` property. 

The long-term solution would be fixing the `IconHandler` class. 
This PR is a short-team solution, ie, adding description for the `icon_path` mentioning that only text-based 
(well most of cases, SVG) are supported.