### PR TITLE
don't rewrite relative paths in Location

### DIFF
--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -273,10 +273,14 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         # Parse the location header
         parsed = urlparse(location)
 
-        # Only rewrite if the location is a relative path (no scheme or host)
+        # Only rewrite if the location is an absolute path (no scheme or host, not a relative path)
         if parsed.scheme or parsed.netloc:
             # Absolute URL - leave as is
-            self.log.debug(f"Not rewriting absolute Location header: {location}")
+            self.log.debug(f"Not rewriting full URL Location header: {location}")
+            return location
+        # Relative paths should work file
+        if not location.startswith("/"):
+            self.log.debug(f"Not rewriting relative Location header: {location}")
             return location
 
         # Get the proxy context path

--- a/tests/resources/redirectserver.py
+++ b/tests/resources/redirectserver.py
@@ -36,7 +36,11 @@ class RedirectHandler(BaseHTTPRequestHandler):
         elif not path.endswith("/"):
             # Add trailing slash, preserve query string
             # relative redirect (/abs/foo -> foo/)
-            new_path = path.rpartition("/")[-1] + "/"
+            # unless starts with `python-redirect-abs`
+            if path.startswith("/python-redirect-abs/"):
+                new_path = path + "/"
+            else:
+                new_path = path.rpartition("/")[-1] + "/"
             if query:
                 new_location = f"{new_path}?{query}"
             else:

--- a/tests/resources/redirectserver.py
+++ b/tests/resources/redirectserver.py
@@ -35,7 +35,8 @@ class RedirectHandler(BaseHTTPRequestHandler):
             self.wfile.write(b"Redirecting...\n")
         elif not path.endswith("/"):
             # Add trailing slash, preserve query string
-            new_path = path + "/"
+            # relative redirect (/abs/foo -> foo/)
+            new_path = path.rpartition("/")[-1] + "/"
             if query:
                 new_location = f"{new_path}?{query}"
             else:

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -538,7 +538,7 @@ def test_server_proxy_redirect_location_header_rewrite(
     the proxy prefix.
 
     This can happen when servers like python's http.server issue 301
-    redirects with relative Location headers (e.g., /subdir/) that don't
+    redirects with absolute path Location headers (e.g., /subdir/) that don't
     include the proxy prefix, causing 404 errors.
     """
     PORT, TOKEN = a_server_port_and_token
@@ -547,9 +547,9 @@ def test_server_proxy_redirect_location_header_rewrite(
     r = request_get(PORT, "/python-redirect/mydir", TOKEN)
     assert r.code == 301
     location = r.headers.get("Location")
-    # Should be rewritten to include the proxy prefix
+    # this redirect is relative and should NOT be rewritten
     # The token query parameter should be preserved in the redirect
-    assert location == f"/python-redirect/mydir/?token={TOKEN}"
+    assert location == f"mydir/?token={TOKEN}"
 
     # Test 2: Named server proxy - explicit redirect-to endpoint
     r = request_get(PORT, "/python-redirect/redirect-to/target/path", TOKEN)


### PR DESCRIPTION
only absolute paths need a rewrite (start with /, no scheme)

relative paths should resolve fine, because they are relative and not sensitive to prefixes.

I found this in [jupyter myst build proxy](https://github.com/ryanlovett/jupyter-myst-build-proxy/blob/fa81d1791cd78aa6fde32d1bcdde8f37577df4a8/jupyter_myst_build_proxy/static_server.py#L432) which uses a relative redirect so that it will behave properly under a prefix path, but jupyter server proxy breaks relative redirects, treating them as absolute, turning a redirect from `/prefix/path/to/some/foo` -> `foo/` into `/prefix/foo/` instead of the correct `/prefix/path/to/some/foo/`
