### PR TITLE
Fix launcher icons for custom categories

### DIFF
--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -122,7 +122,7 @@ the following keys:
    explicit entry.
 2. **icon_path**
    Full path to an icon file that could be used with a launcher (for example, `.svg` or `.png`).
-   Currently only used by the JupyterLab launcher, when category is "Notebook" (default) or "Console".
+   Currently only used by the JupyterLab launcher and the Notebook 7 Servers menu.
 3. **title**
    Title to be used for the launcher entry. Defaults to the name of the server if missing.
 4. **path_info**

--- a/labextension/src/index.ts
+++ b/labextension/src/index.ts
@@ -139,6 +139,7 @@ async function activate(
   // load and trust the JSON as a type of data described by the `IServersInfo` interface
   // TODO: consider adding JSON schema-derived types
   const data = (await response.json()) as IServersInfo;
+  const launcherIconClasses = addLauncherIconStyles(data.server_processes);
 
   // handle restoring persistent JupyterLab workspace widgets on page reload
   // this is created even in the Notebook `tree` page to reduce complexity below
@@ -162,6 +163,7 @@ async function activate(
   const { commands, shell } = app;
   commands.addCommand(CommandIDs.open, {
     label: (args) => (args as IOpenArgs).title,
+    iconClass: (args) => launcherIconClasses.get((args as IOpenArgs).id) || "",
     describedBy: async () => {
       return { args: argSchema };
     },
@@ -232,6 +234,36 @@ async function activate(
       }
     }
   }
+}
+
+function addLauncherIconStyles(
+  serverProcesses: IServerProcess[],
+): Map<string, string> {
+  const iconClasses = new Map<string, string>();
+  const entries = serverProcesses.filter(
+    ({ launcher_entry }) => launcher_entry.icon_url,
+  );
+
+  if (!entries.length) {
+    return iconClasses;
+  }
+
+  const style = document.createElement("style");
+  style.dataset.serverProxyLauncherIcons = "";
+  document.head.appendChild(style);
+
+  for (const [index, { launcher_entry, name }] of entries.entries()) {
+    const className = `jp-ServerProxyIcon-${index}`;
+    const ruleIndex = style.sheet!.insertRule(`.${className} {}`);
+    const rule = style.sheet!.cssRules[ruleIndex] as CSSStyleRule;
+    rule.style.backgroundImage = `url(${JSON.stringify(launcher_entry.icon_url)})`;
+    rule.style.backgroundPosition = "center";
+    rule.style.backgroundRepeat = "no-repeat";
+    rule.style.backgroundSize = "contain";
+    iconClasses.set(`${NS}:${name}`, className);
+  }
+
+  return iconClasses;
 }
 
 /**

--- a/tests/acceptance/Lab.robot
+++ b/tests/acceptance/Lab.robot
@@ -16,6 +16,15 @@ ${CSS_LAUNCHER_CARD}   css:.jp-LauncherCard-label
 Lab Loads
     Capture Page Screenshot    00-smoke.png
 
+Custom Category Icon
+    ${selector} =    Set Variable    css:.jp-LauncherCard[title^="foo"] .jp-LauncherCard-icon > *
+    Wait Until Element Is Visible    ${selector}    timeout=10s
+    ${item} =    Get WebElement    ${selector}
+    ${background_image} =    Execute Javascript
+    ...    return window.getComputedStyle(arguments[0]).backgroundImage;
+    ...    ARGUMENTS    ${item}
+    Should Contain    ${background_image}    /server-proxy/icon/foo
+
 Launch Browser Tab
     Click Launcher    foo
     Wait Until Keyword Succeeds    3x    0.5s    Switch Window    title:Hello World

--- a/tests/acceptance/resources/icon.svg
+++ b/tests/acceptance/resources/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M3 5h7l2 2h9v12H3z" />
+</svg>

--- a/tests/acceptance/resources/jupyter_config.json
+++ b/tests/acceptance/resources/jupyter_config.json
@@ -4,7 +4,9 @@
       "foo": {
         "command": ["python", "-m", "http.server", "{port}"],
         "launcher_entry": {
-          "title": "foo"
+          "title": "foo",
+          "category": "Other",
+          "icon_path": "icon.svg"
         }
       },
       "bar": {


### PR DESCRIPTION
### Checklist

- [x] I am the author of this work

### What does this PR do?

Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation
- [ ] Maintenance (testing, packaging, infrastructure, metadata)
- [ ] Other

This PR allows JupyterLab launcher entries in custom, non-kernel categories, such as `Other`, to display the icon configured through `icon_path`.

Launcher entries in the `Notebook` and `Console` categories continue to use their existing kernel icons. An acceptance test verifies that a launcher entry in a custom category displays its
configured icon.

The documentation also notes that the configured command icon may appear in Notebook 7's Servers menu.

### Is this PR related to an issue, or is it part of a larger body of work?

No related issue.

### Does this PR introduce a breaking change?

No. Existing behavior for the `Notebook` and `Console` launcher categories is preserved.

### How can this PR be tested?

The following checks were run:

- `jlpm prettier --check "src/**/*.{tsx,ts}"`
- `jlpm build:lib`
- Full Python test suite: 121 passed
- The browser acceptance test was run with Firefox and Selenium and passed.

The added acceptance test configures a server entry in the `Other` category with an SVG `icon_path`, opens JupyterLab, and verifies that the corresponding launcher tile displays the icon.

### What should a reviewer concentrate their feedback on?

Please review:

- Whether applying `icon_path` to all launcher categories except `Notebook` and `Console` is the appropriate way to preserve kernel icon behavior.
- Whether sharing the configured command icon between the JupyterLab launcher and Notebook 7's Servers menu is the intended behavior.
- Whether the acceptance-test coverage is sufficient.

### Other information

AI assistance was used to inspect the repository, prepare the implementation, and investigate test behavior. I did not understand the syntax in some cases, but I tried to understand what each changed line did and why it was changed, and I take responsibility for the contribution.