### PR TITLE
Add exclude_last_activity_patterns to prevent some requests from keeping server alive

### DIFF
--- a/docs/source/server-process.md
+++ b/docs/source/server-process.md
@@ -161,10 +161,29 @@ One of:
 Whether to report activity from the proxy to Jupyter Server. If _True_, Jupyter Server
 will be notified of new activity. This is primarily used by JupyterHub for idle detection and culling.
 
-Useful if you want to have a seperate way of determining activity through a
+Useful if you want to have a separate way of determining activity through a
 proxied application.
 
 Defaults to _True_.
+
+```{versionchanged} 4.6.0
+`update_last_activity` may be a callable, given the current RequestHandler,
+which should return True or False to track the current handler.
+```
+
+### `exclude_last_activity_patterns`
+
+```{versionadded} 4.6.0
+
+```
+
+Specify a list of regular expressions (patterns as strings, or compiled regular expression objects)
+to _not_ be registered as activity.
+Patterns are tested on the path of the request (e.g. `[".*/proxy/123/some-endpoint$"]` would match `/user/name/proxy/123/some-endpoint`).
+
+Useful if a proxied application makes certain polling requests constantly, even when idle,
+to avoid those requests keeping an actually idle server from appearing to be busy.
+An example being RStudio's `.../rstudio/events/get_events`.
 
 (server-process:callable-arguments)=
 

--- a/jupyter_server_proxy/config.py
+++ b/jupyter_server_proxy/config.py
@@ -4,6 +4,7 @@ Traitlets based configuration for jupyter_server_proxy
 
 from __future__ import annotations
 
+import re
 import sys
 from textwrap import dedent, indent
 from warnings import warn
@@ -254,9 +255,46 @@ class ServerProcess(Configurable):
     """,
     ).tag(config=True)
 
-    update_last_activity = Bool(
-        True, help="Will cause the proxy to report activity back to jupyter server."
+    update_last_activity = Union(
+        [Bool(), Callable()],
+        default_value=True,
+        help="""
+        Should proxied activity be considered activity on the server?
+
+        If True (default), any request to the proxied application will be considered activity on the server,
+        which is used when calculating 'idleness' for the purposes of automatic shutdown, etc.
+
+        If Callable, will be called with the Request as the only argument,
+        and must return True (update last_activity) or False (don't update last_activity).
+
+        .. versionadded:: 4.6
+        
+            callable support added.
+
+        """,
     ).tag(config=True)
+
+    exclude_last_activity_patterns = List(
+        Union([Unicode(), Instance(re.Pattern)]),
+        help="""
+        List of regular expressions (pattern strings or already compiled) of request paths to be excluded from activity tracking.
+
+        Pattern is only applied to the path (not the full URL).
+
+        This allows excluding URL patterns that tend to get requests when an application is actually idle,
+        e.g. background polling requests that still occur while a user is not 'actively' using the application.
+
+        Only considered if `update_last_activity` is True,
+        has no effect if `update_last_activity` is False or a callable.
+
+        .. versionadded:: 4.6
+        """,
+    ).tag(config=True)
+
+    @validate("exclude_last_activity_patterns")
+    def _compile_last_activity_patterns(self, proposal):
+        # re.compile is a no-op on re.Pattern, so don't need to check
+        return [re.compile(pattern) for pattern in proposal.value]
 
     raw_socket_proxy = Bool(
         False,
@@ -302,6 +340,7 @@ class ServerProcess(Configurable):
             "mappath": self.mappath,
             "rewrite_response": self.rewrite_response,
             "update_last_activity": self.update_last_activity,
+            "exclude_last_activity_patterns": self.exclude_last_activity_patterns,
             "request_headers_override": self.request_headers_override,
         }
 

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -119,6 +119,10 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         )
         self._requested_subprotocols = None
         self.update_last_activity = kwargs.pop("update_last_activity", True)
+        self.exclude_last_activity_patterns = [
+            re.compile(pattern)
+            for pattern in kwargs.pop("exclude_last_activity_patterns", [])
+        ]
         super().__init__(*args, **kwargs)
 
     # Support/use jupyter_server config arguments allow_origin and allow_origin_pat
@@ -236,7 +240,20 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         avoids proxied traffic being ignored by the notebook's
         internal idle-shutdown mechanism
         """
-        if self.update_last_activity:
+        update_last_activity = self.update_last_activity
+        if not update_last_activity:
+            return
+        # allow update_last_activity to be a callable
+        if callable(update_last_activity):
+            update_last_activity = update_last_activity(self)
+        else:
+            # allow excluding traffic that can still happen on 'idle',
+            # such as RStudio's `get_events` endpoint
+            path = self.request.path
+            for pattern in self.exclude_last_activity_patterns:
+                if pattern.match(path):
+                    return
+        if update_last_activity:
             self.settings["api_last_activity"] = utcnow()
 
     def _get_context_path(self, host, port):

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -119,10 +119,9 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
         )
         self._requested_subprotocols = None
         self.update_last_activity = kwargs.pop("update_last_activity", True)
-        self.exclude_last_activity_patterns = [
-            re.compile(pattern)
-            for pattern in kwargs.pop("exclude_last_activity_patterns", [])
-        ]
+        self.exclude_last_activity_patterns = kwargs.pop(
+            "exclude_last_activity_patterns", []
+        )
         super().__init__(*args, **kwargs)
 
     # Support/use jupyter_server config arguments allow_origin and allow_origin_pat

--- a/jupyter_server_proxy/handlers.py
+++ b/jupyter_server_proxy/handlers.py
@@ -254,7 +254,10 @@ class ProxyHandler(WebSocketHandlerMixin, JupyterHandler):
                 if pattern.match(path):
                     return
         if update_last_activity:
-            self.settings["api_last_activity"] = utcnow()
+            # Jupyter Server uses this dictionary to collect activity times from extensions
+            # but don't assume it exists (e.g. standalone server)
+            last_activity_times = self.settings.setdefault("last_activity_times", {})
+            last_activity_times["jupyter-server-proxy"] = utcnow()
 
     def _get_context_path(self, host, port):
         """

--- a/jupyter_server_proxy/standalone/app.py
+++ b/jupyter_server_proxy/standalone/app.py
@@ -59,7 +59,7 @@ class StandaloneProxyServer(JupyterApp, ServerProcess):
         return prefix
 
     no_authentication = Bool(
-        default=False,
+        False,
         help="""
         Do not authenticate access to the server via JupyterHub. When set,
         incoming requests will not be authenticated and anyone can access the

--- a/tests/resources/jupyter_server_config.py
+++ b/tests/resources/jupyter_server_config.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from pathlib import Path
 
@@ -49,6 +50,13 @@ def cats_only(response, path):
 
 def my_env():
     return {"MYVAR": "String with escaped {{var}}"}
+
+
+def last_activity_param(request):
+    if request.get_argument("ignore_activity", None):
+        return False
+    else:
+        return True
 
 
 c.ServerProxy.servers = {
@@ -124,6 +132,21 @@ c.ServerProxy.servers = {
         "request_headers_override": {
             "X-Custom-Header": "pytest-23456",
         },
+    },
+    "disable-last-activity": {
+        "command": [sys.executable, _get_path("httpinfo.py"), "--port={port}"],
+        "update_last_activity": False,
+    },
+    "callable-last-activity": {
+        "command": [sys.executable, _get_path("httpinfo.py"), "--port={port}"],
+        "update_last_activity": last_activity_param,
+    },
+    "exclude-last-activity": {
+        "command": [sys.executable, _get_path("httpinfo.py"), "--port={port}"],
+        "exclude_last_activity_patterns": [
+            r".*/ignore-me$",
+            re.compile(".*/ignored/.*"),
+        ],
     },
     "python-gzipserver": {
         "command": [sys.executable, _get_path("gzipserver.py"), "{port}"],

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -2,7 +2,6 @@ import gzip
 import json
 import sys
 import time
-from datetime import datetime
 from functools import partial
 from http.client import HTTPConnection
 from io import BytesIO
@@ -653,7 +652,7 @@ def test_last_activity(
         body = r.read().decode("utf8", "replace")
         assert r.code == 200
         status = json.loads(body)
-        return datetime.fromisoformat(status["last_activity"])
+        return status["last_activity"]
 
     before = get_activity()
     # assumes request takes a measurable amount of time,

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -2,6 +2,8 @@ import gzip
 import json
 import sys
 import time
+from datetime import datetime
+from functools import partial
 from http.client import HTTPConnection
 from io import BytesIO
 from typing import Tuple
@@ -625,3 +627,41 @@ def test_server_proxy_icon_handler_png(
 
     body = r.read()
     assert body.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+@pytest.mark.parametrize(
+    "url, expect_activity",
+    [
+        ("/disable-last-activity/anything", False),
+        ("/callable-last-activity/tracked", True),
+        ("/callable-last-activity/tracked?ignore_activity=1", False),
+        ("/exclude-last-activity/tracked", True),
+        ("/exclude-last-activity/something/ignore-me", False),
+        ("/exclude-last-activity/ignored/something", False),
+    ],
+)
+def test_last_activity(
+    a_server_port_and_token: Tuple[int, str],
+    url,
+    expect_activity,
+) -> None:
+    PORT, TOKEN = a_server_port_and_token
+    get = partial(request_get, PORT, token=TOKEN)
+
+    def get_activity():
+        r = get("/api/status")
+        body = r.read().decode("utf8", "replace")
+        assert r.code == 200
+        status = json.loads(body)
+        return datetime.fromisoformat(status["last_activity"])
+
+    before = get_activity()
+    # assumes request takes a measurable amount of time,
+    # may need to add a sleep if there are low-resolution timers
+    r = get(url)
+    assert r.code == 200
+    after = get_activity()
+    if expect_activity:
+        assert after > before
+    else:
+        assert after == before


### PR DESCRIPTION
allows for excluding certain endpoints from activity that might keep the server alive even when it's really idle.

and allow update_last_activity to be a callable

<!--
Thank you for contributing to this repository!

You can help us review your changes by answering these questions.
They are all optional, but the more information you provide the easier it will be for us to review your changes.
Everyone here is a volunteer, so please help us out if you can.

If you want to discuss anything Jupyter related, or to meet other users and developers, please say hello on https://discourse.jupyter.org/ .
-->

### Checklist

<!--
Checklist of things you should always do before contributing

Make sure to read our policy if you have used an LLM in preparing this contribution.

https://compass.hub.jupyter.org/contribute/llm/

Automated contributions are not permitted.

By 'this work', we mean any code, documentation, as well as the PR description and any comments you post in the discussion.
-->

- [x] I am the author of this work

### What does this PR do?
<!--
Please indicate the type of change made by this PR (tick one or more of the boxes) and summarise the PR.
Please also edit the PR title so that it contains enough context to go into a changelog.
It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
-->
Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Maintenance (testing, packaging, infrastructure, metadata)
- [ ] Other

### Is this PR related to an issue, or is it part of a larger body of work?
<!--
Please feel free to provide as much context or links to external sites as you want!
Use "Fixes #<NUM>" or "Fixes <URL to GitHub issue>" if this fixes an existing issue.
-->

### Does this PR introduce a breaking change?
<!--
If so what changes might users need to make in their applications due to this PR?
-->

### How can this PR be tested?
<!--
If this is not fully covered by the automated tests please help us by describing the tests that you ran to verify your changes. Make sure to provide as much detail so that we can reproduce your tests.
-->

set `exclude_last_activity_patterns` and submit requests. last_activity should not be updated.

### What should a reviewer concentrate their feedback on?
<!--
This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
You can use bullet points "-" if it helps.
-->

if this is adequate configuration, or if it should be expressed differently

### Other information
<!--
Please provide any other information you think is relevant
-->

cc @shaneknapp who's dealing with lots of idle rstudio sessions not being culled due to constant `POST /rstudio/events/get_events`

I'll do another PR against rsession-proxy to ignore get_events by default